### PR TITLE
Fix deprecated alias HomeAssistantType

### DIFF
--- a/custom_components/pgnig_gas_sensor/sensor.py
+++ b/custom_components/pgnig_gas_sensor/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import SensorEntity, PLATFORM_SCHEMA, Senso
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, UnitOfVolume
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, HomeAssistantType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 
 from .Invoices import InvoicesList
@@ -50,7 +50,7 @@ async def async_setup_entry(
 
 
 async def async_setup_platform(
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         config: ConfigType,
         async_add_entities: Callable,
         discovery_info: Optional[DiscoveryInfoType] = None,


### PR DESCRIPTION
Replace the deprecated alias `HomeAssistantType` with `homeassistant.core.HomeAssistant` in `custom_components/pgnig_gas_sensor/sensor.py`.

* Remove the import statement for `HomeAssistantType`.
* Update the `async_setup_platform` function to use `HomeAssistant` instead of `HomeAssistantType`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pawelhulek/pgnig-sensor/pull/71?shareId=837b0b9b-dda1-4b83-a273-0de9436a9ca4).