### PR TITLE
Fix async setup entry in pgnig_gas_sensor

### DIFF
--- a/custom_components/pgnig_gas_sensor/__init__.py
+++ b/custom_components/pgnig_gas_sensor/__init__.py
@@ -28,9 +28,7 @@ async def async_setup_entry(hass, config_entry):
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
-    )
+    await hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
     return True
 
 


### PR DESCRIPTION
Update `async_setup_entry` function to await `async_forward_entry_setup` call.

* Modify `custom_components/pgnig_gas_sensor/__init__.py` to await `hass.config_entries.async_forward_entry_setup` in the `async_setup_entry` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pawelhulek/pgnig-sensor/pull/72?shareId=0cff09b0-5e4f-45f0-88d0-cd7d55a94ba1).