### PR TITLE
fix: config flow crash + OrlenID reliability fixes

### DIFF
--- a/custom_components/pgnig_gas_sensor/PgnigApi.py
+++ b/custom_components/pgnig_gas_sensor/PgnigApi.py
@@ -1,4 +1,6 @@
+import logging
 import string
+import threading
 
 import requests
 
@@ -7,6 +9,8 @@ from .PgpList import (PpgList, ppg_list_from_dict)
 from .PpgReadingForMeter import PpgReadingForMeter, ppg_reading_for_meter_from_dict
 from .auth import AuthRegistry
 from .const import DEFAULT_AUTH_METHOD
+
+_LOGGER = logging.getLogger(__name__)
 
 login_url = "https://ebok.myorlen.pl/auth/login?api-version=3.0"
 devices_list_url = "https://ebok.myorlen.pl/crm/get-ppg-list?api-version=3.0"
@@ -27,13 +31,22 @@ class PgnigApi:
         if auth_class is None:
             raise ValueError(f"Unknown auth method: {auth_method}")
         self._auth = auth_class(username, password)
+        self._token: str | None = None
+        self._token_lock = threading.Lock()
 
     def meterList(self) -> PpgList:
-        return ppg_list_from_dict(requests.get(devices_list_url, headers={
+        response = requests.get(devices_list_url, headers={
             'Content-Type': 'application/json',
             'Accept': 'application/json',
             'AuthToken': self.login()
-        }).json())
+        }, timeout=30)
+        _LOGGER.debug("meterList: HTTP %s body=%s", response.status_code, response.text[:500])
+        data = response.json()
+        if not isinstance(data, dict) or "PpgList" not in data:
+            raise RuntimeError(
+                f"meterList unexpected response (HTTP {response.status_code}): {response.text[:200]}"
+            )
+        return ppg_list_from_dict(data)
 
     def readingForMeter(self, meter_id) -> PpgReadingForMeter:
         return ppg_reading_for_meter_from_dict(requests.get(readings_url + meter_id, headers={
@@ -50,4 +63,12 @@ class PgnigApi:
         }).json())
 
     def login(self) -> string:
-        return self._auth.login()
+        with self._token_lock:
+            if self._token:
+                return self._token
+            self._token = self._auth.login()
+            return self._token
+
+    def invalidate_token(self) -> None:
+        with self._token_lock:
+            self._token = None

--- a/custom_components/pgnig_gas_sensor/auth/api_login.py
+++ b/custom_components/pgnig_gas_sensor/auth/api_login.py
@@ -1,7 +1,11 @@
 """Legacy API login strategy for Orlen EBOK."""
+import logging
+
 import requests
 
 from . import AuthMethod, AuthMethodInfo, AuthRegistry, device_id
+
+_LOGGER = logging.getLogger(__name__)
 
 login_url = "https://ebok.myorlen.pl/auth/login?api-version=3.0"
 headers = {
@@ -31,4 +35,18 @@ class ApiLoginAuth(AuthMethod):
                    "DeviceId": device_id(self.username),
                    "DeviceName": "Home Assistant: 99.9.999.99<br>",
                    "DeviceType": "Web"}
-        return requests.request('POST', login_url, headers=headers, json=payload).json().get('Token')
+        response = requests.post(login_url, headers=headers, json=payload, timeout=30)
+        _LOGGER.debug("Legacy login HTTP %s — body: %s", response.status_code, response.text[:500])
+        try:
+            data = response.json()
+        except ValueError as err:
+            raise RuntimeError(
+                f"Login returned non-JSON (HTTP {response.status_code}): {response.text[:200]}"
+            ) from err
+
+        token = data.get("Token")
+        if not token:
+            raise RuntimeError(
+                f"Login failed (HTTP {response.status_code}): no Token in response — {data}"
+            )
+        return token

--- a/custom_components/pgnig_gas_sensor/auth/orlen_id.py
+++ b/custom_components/pgnig_gas_sensor/auth/orlen_id.py
@@ -1,9 +1,16 @@
 """OrlenID OID login strategy for Orlen EBOK."""
+import logging
 import re
 
 import requests
 
 from . import AuthMethod, AuthMethodInfo, AuthRegistry, device_id
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class InvalidAuthError(Exception):
+    """Raised when OrlenID rejects the supplied credentials."""
 
 
 @AuthRegistry.register
@@ -37,24 +44,45 @@ class OrlenIDAuth(AuthMethod):
             "FinalizeRegistrationRedirectUrl": "https://ebok.myorlen.pl/aktywuj-oid/"
         }
 
-        response_init = session.post(init_url, json=init_data, headers={'Content-Type': 'application/json'})
+        response_init = session.post(
+            init_url, json=init_data, headers={'Content-Type': 'application/json'}, timeout=30
+        )
+        if response_init.status_code != 200:
+            raise RuntimeError(
+                f"OrlenID init-login failed (HTTP {response_init.status_code}): {response_init.text[:200]}"
+            )
         redirect_url = response_init.json().get('RedirectUrl')
-        response_page = session.get(redirect_url, headers=headers)
+        if not redirect_url:
+            raise RuntimeError(f"OrlenID init-login missing RedirectUrl: {response_init.text[:200]}")
+
+        response_page = session.get(redirect_url, headers=headers, timeout=30)
         match = re.search(r'action="([^"]+)"', response_page.text)
+        if not match:
+            raise RuntimeError("OrlenID login page missing form action — login flow may have changed")
 
-        if match:
-            post_url = match.group(1).replace('&amp;', '&')
-            payload = {
-                'username': self.username,
-                'password': self.password,
-                'credentialId': ''
-            }
-            final_response = session.post(post_url, data=payload, headers=headers)
+        post_url = match.group(1).replace('&amp;', '&')
+        payload = {
+            'username': self.username,
+            'password': self.password,
+            'credentialId': ''
+        }
+        final_response = session.post(post_url, data=payload, headers=headers, timeout=30)
+        _LOGGER.debug("OrlenID final URL=%s status=%s", final_response.url, final_response.status_code)
 
-            if "https://ebok.myorlen.pl/home" in final_response.url:
-                auth_token_url = f'https://ebok.myorlen.pl/auth/get-auth-token?deviceId={init_data["DeviceId"]}&api-version=3.0'
-                headers.update({'Referer': 'https://ebok.myorlen.pl/'})
-                res_auth = session.get(auth_token_url, headers=headers)
-                if res_auth.status_code == 200:
-                    return res_auth.json().get('Token')
-        return ""
+        if "https://ebok.myorlen.pl/home" not in final_response.url:
+            raise InvalidAuthError(
+                "OrlenID rejected credentials — username or password is incorrect"
+            )
+
+        auth_token_url = f'https://ebok.myorlen.pl/auth/get-auth-token?deviceId={init_data["DeviceId"]}&api-version=3.0'
+        headers.update({'Referer': 'https://ebok.myorlen.pl/'})
+        res_auth = session.get(auth_token_url, headers=headers, timeout=30)
+        if res_auth.status_code != 200:
+            raise RuntimeError(
+                f"OrlenID get-auth-token failed (HTTP {res_auth.status_code}): {res_auth.text[:200]}"
+            )
+
+        token = res_auth.json().get('Token')
+        if not token:
+            raise RuntimeError(f"OrlenID get-auth-token missing Token: {res_auth.text[:200]}")
+        return token

--- a/custom_components/pgnig_gas_sensor/config_flow.py
+++ b/custom_components/pgnig_gas_sensor/config_flow.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional, Dict, Any
 
 import homeassistant.helpers.config_validation as cv
@@ -9,6 +10,8 @@ from .auth import AuthRegistry
 from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
 from .PgnigApi import PgnigApi
 
+_LOGGER = logging.getLogger(__name__)
+
 AUTH_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
@@ -16,6 +19,9 @@ AUTH_SCHEMA = vol.Schema({
 
 
 class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
+    def __init__(self) -> None:
+        self._auth_method: Optional[str] = None
+
     async def async_step_import(self, import_config):
         return self.async_abort(reason="one_instance_at_a_time_please")
 
@@ -23,13 +29,12 @@ class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
         methods = AuthRegistry.list()
 
         if len(methods) == 1:
-            return await self.async_step_credentials({
-                CONF_AUTH_METHOD: methods[0].id,
-                **(user_input or {}),
-            })
+            self._auth_method = methods[0].id
+            return await self.async_step_credentials()
 
         if user_input is not None and CONF_AUTH_METHOD in user_input:
-            return await self.async_step_credentials(user_input)
+            self._auth_method = user_input[CONF_AUTH_METHOD]
+            return await self.async_step_credentials()
 
         options = [(m.id, m.name) for m in methods]
         return self.async_show_form(
@@ -42,9 +47,9 @@ class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_credentials(self, user_input: Optional[Dict[str, Any]] = None):
         errors: Dict[str, str] = {}
         description_placeholders: Dict[str, str] = {"error_info": ""}
+        auth_method = self._auth_method or DEFAULT_AUTH_METHOD
 
         if user_input is not None:
-            auth_method = user_input.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
             username = user_input.get(CONF_USERNAME)
             password = user_input.get(CONF_PASSWORD)
 
@@ -57,24 +62,14 @@ class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_AUTH_METHOD: auth_method,
                 }
                 return self.async_create_entry(title="Pgnig sensor", data=data)
-            except Exception:
+            except Exception as err:
+                _LOGGER.exception("Orlen EBOK login failed: %s", err)
                 errors = {"base": "verify_connection_failed"}
-                description_placeholders = {"error_info": "EBOK Login Failed"}
-
-        step_data = {}
-        if user_input and CONF_AUTH_METHOD in user_input:
-            step_data[CONF_AUTH_METHOD] = user_input[CONF_AUTH_METHOD]
-
-        schema_dict: Dict[str, Any] = {
-            vol.Required(CONF_USERNAME): cv.string,
-            vol.Required(CONF_PASSWORD): cv.string,
-        }
-        if CONF_AUTH_METHOD in step_data:
-            schema_dict[CONF_AUTH_METHOD] = vol.Hidden()
+                description_placeholders = {"error_info": f"EBOK Login Failed: {err}"}
 
         return self.async_show_form(
             step_id="credentials",
-            data_schema=vol.Schema(schema_dict),
+            data_schema=AUTH_SCHEMA,
             errors=errors,
             description_placeholders=description_placeholders,
         )


### PR DESCRIPTION
## Summary

While testing the OrlenID branch (`V2.9.9-new-login`) on Home Assistant 2026.5.2 I hit a chain of issues — the config flow crashed, errors were swallowed silently, the OrlenID flow returned an empty token on wrong password (causing a cryptic `TypeError` downstream), and concurrent logins during initial setup caused some sensor entities to register without state until the integration was reloaded.

This PR fixes all of them. Two commits, grouped by theme.

---

### Commit 1 — Config flow crash + surface real login errors

#### `AttributeError: module 'voluptuous' has no attribute 'Hidden'`
`config_flow.py:73` referenced `vol.Hidden()`, which is not part of the voluptuous API. The exception was raised on every render of the credentials step, and HA fell back to a malformed dialog showing the `auth_method` radio buttons on top of the "Enter the credentials to your Orlen EBOK" title.

**Fix:** removed the `vol.Hidden()` hack. The selected auth method is now stored on the flow instance (`self._auth_method`) in `async_step_user` and reused in `async_step_credentials` — no need to round-trip it through the form schema. The credentials form now cleanly shows only username + password.

#### Silent `except Exception`
The credentials step caught any login exception and rendered a generic `"EBOK Login Failed"` placeholder without logging anything. The real cause (e.g. HTTP 403 from the legacy endpoint for migrated accounts) was invisible.

**Fix:** added `_LOGGER.exception(...)` and surfaced the exception text into the dialog via `description_placeholders` — `"EBOK Login Failed: <reason>"`.

#### Legacy `api_login` returning `None` on failure
`auth/api_login.py` did `requests.request(...).json().get('Token')` — when the response was not JSON or had no `Token`, it returned `None` silently and the config flow happily called `async_create_entry`, creating a broken entry.

**Fix:** explicit HTTP/JSON handling — raises `RuntimeError` with status code + body snippet on non-JSON responses or missing `Token`. Added a 30s timeout and a debug log of the response body.

---

### Commit 2 — OrlenID silent failures + token caching

#### Wrong password → cryptic `TypeError: 'NoneType' object is not iterable`
`auth/orlen_id.py` returned `""` for every non-happy-path branch — most importantly, wrong credentials (SSO redirect doesn't land on `/home`). The empty token then flowed into `/crm/get-ppg-list` as `AuthToken: ""`, Orlen replied with a JSON error body, and `PgpList.from_list` crashed iterating `None`. Symptoms in issue #88 included `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` on legacy and `TypeError: 'NoneType' object is not iterable` on OrlenID — both the same root cause.

**Fix:** every silent branch now raises explicitly:
- `InvalidAuthError("OrlenID rejected credentials — username or password is incorrect")` when SSO doesn't land on `/home`
- `RuntimeError` with HTTP status + body snippet on non-200 init/auth-token, missing `RedirectUrl`, missing form action, or missing `Token`
- 30s timeouts on all three HTTP requests

#### Sensors missing on initial setup until reload
`sensor.py:async_setup_entry` calls `meterList()` then adds three entities per meter with `update_before_add=True`. Each entity's `async_update` calls `self.api.readingForMeter()` / `self.api.invoices()`, **and each of those re-runs the full login flow**. So initial setup ran **four parallel OrlenID logins** (one for `meterList`, three from the concurrent entity updates). The SSO race caused some logins to return empty/error responses; affected sensors registered with state=None until the user manually reloaded the integration.

**Fix:** `PgnigApi` now caches the auth token on the instance behind a `threading.Lock`. First caller does the real login under the lock; concurrent callers wait and reuse the cached token. Initial setup now performs **one** OrlenID flow total. Added `PgnigApi.invalidate_token()` (not wired up yet) for future 401-retry logic.

#### Defensive check in `meterList`
Even with proper auth, an unexpected Orlen response shape (e.g. server error returned as JSON without `PpgList`) crashed in the parser. `meterList` now raises `RuntimeError` with HTTP status + body when the response isn't a dict or lacks `PpgList`, plus a 30s timeout and a debug log.

---

## Test plan

- [x] Reproduced the original `vol.Hidden()` crash on HA 2026.5.2.
- [x] After fix: legacy auth path renders cleanly; on bad creds dialog shows `HTTP 403` (Orlen WAF rejecting migrated accounts) instead of `Unknown error occurred`.
- [x] Reproduced the "wrong password" path on OrlenID — now shows `EBOK Login Failed: OrlenID rejected credentials — username or password is incorrect` instead of cryptic `TypeError`.
- [x] OrlenID auth path with correct credentials: config entry created, all three sensors per meter register populated on first setup (no reload needed).
- [ ] `async_step_reauth` / `async_step_reconfigure` paths — unchanged in this PR, worth a quick smoke test.

## Notes

- `manifest.json` version unchanged — happy to bump if you'd like.
- No `strings.json` changes needed; the `{error_info}` translation errors observed before the fix were a downstream artifact of the `vol.Hidden` crash (the placeholders were never supplied because the form-render path crashed).
- Debug log in `auth/api_login.py` includes a 500-char body snippet of the login response — at success this contains the `Token`. Only fires at `debug` level, but worth flagging in case you'd prefer to log only on error paths.