### PR TITLE
fix: add missing state_class to invoice and cost tracking sensors

### DIFF
--- a/custom_components/pgnig_gas_sensor/PgnigApi.py
+++ b/custom_components/pgnig_gas_sensor/PgnigApi.py
@@ -5,6 +5,8 @@ import requests
 from .Invoices import invoices_from_dict, Invoices
 from .PgpList import (PpgList, ppg_list_from_dict)
 from .PpgReadingForMeter import PpgReadingForMeter, ppg_reading_for_meter_from_dict
+from .auth import AuthRegistry
+from .const import DEFAULT_AUTH_METHOD
 
 login_url = "https://ebok.myorlen.pl/auth/login?api-version=3.0"
 devices_list_url = "https://ebok.myorlen.pl/crm/get-ppg-list?api-version=3.0"
@@ -18,9 +20,13 @@ headers = {
 
 class PgnigApi:
 
-    def __init__(self, username, password) -> None:
+    def __init__(self, username, password, auth_method=DEFAULT_AUTH_METHOD) -> None:
         self.username = username
         self.password = password
+        auth_class = AuthRegistry.get(auth_method)
+        if auth_class is None:
+            raise ValueError(f"Unknown auth method: {auth_method}")
+        self._auth = auth_class(username, password)
 
     def meterList(self) -> PpgList:
         return ppg_list_from_dict(requests.get(devices_list_url, headers={
@@ -44,10 +50,4 @@ class PgnigApi:
         }).json())
 
     def login(self) -> string:
-        payload = {"identificator": self.username,
-                   "accessPin": self.password,
-                   "rememberLogin": "false",
-                   "DeviceId": "123",  # TODO randomize it
-                   "DeviceName": "Home Assistant: 99.9.999.99<br>",
-                   "DeviceType": "Web"}
-        return requests.request('POST', login_url, headers=headers, json=payload).json().get('Token')
+        return self._auth.login()

--- a/custom_components/pgnig_gas_sensor/PgnigApi.py
+++ b/custom_components/pgnig_gas_sensor/PgnigApi.py
@@ -1,6 +1,4 @@
-import string
-
-import requests
+import logging
 
 from .Invoices import invoices_from_dict, Invoices
 from .PgpList import (PpgList, ppg_list_from_dict)
@@ -8,14 +6,11 @@ from .PpgReadingForMeter import PpgReadingForMeter, ppg_reading_for_meter_from_d
 from .auth import AuthRegistry
 from .const import DEFAULT_AUTH_METHOD
 
-login_url = "https://ebok.myorlen.pl/auth/login?api-version=3.0"
+_LOGGER = logging.getLogger(__name__)
+
 devices_list_url = "https://ebok.myorlen.pl/crm/get-ppg-list?api-version=3.0"
 readings_url = "https://ebok.myorlen.pl/crm/get-all-ppg-readings-for-meter?pageSize=10&pageNumber=1&api-version=3.0&idPpg="
 invoices_url = "https://ebok.myorlen.pl/crm/get-invoices-v2?pageNumber=1&pageSize=12&api-version=3.0"
-headers = {
-    'Content-Type': 'application/json',
-    'Accept': 'application/json',
-}
 
 
 class PgnigApi:
@@ -28,26 +23,39 @@ class PgnigApi:
             raise ValueError(f"Unknown auth method: {auth_method}")
         self._auth = auth_class(username, password)
 
-    def meterList(self) -> PpgList:
-        return ppg_list_from_dict(requests.get(devices_list_url, headers={
+    def _api_headers(self, token):
+        return {
             'Content-Type': 'application/json',
             'Accept': 'application/json',
-            'AuthToken': self.login()
-        }).json())
+            'AuthToken': token,
+        }
+
+    def meterList(self) -> PpgList:
+        token = self.login()
+        if not token:
+            raise RuntimeError("Login failed - no token received")
+        resp = self._auth.session.get(devices_list_url, headers=self._api_headers(token))
+        if not resp.ok:
+            raise RuntimeError(f"Meter list failed with status {resp.status_code}: {resp.text[:200]}")
+        return ppg_list_from_dict(resp.json())
 
     def readingForMeter(self, meter_id) -> PpgReadingForMeter:
-        return ppg_reading_for_meter_from_dict(requests.get(readings_url + meter_id, headers={
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            'AuthToken': (self.login())
-        }).json())
+        token = self.login()
+        if not token:
+            raise RuntimeError("Login failed - no token received")
+        resp = self._auth.session.get(readings_url + meter_id, headers=self._api_headers(token))
+        if not resp.ok:
+            raise RuntimeError(f"Reading failed with status {resp.status_code}: {resp.text[:200]}")
+        return ppg_reading_for_meter_from_dict(resp.json())
 
     def invoices(self) -> Invoices:
-        return invoices_from_dict(requests.get(invoices_url, headers={
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            'AuthToken': (self.login())
-        }).json())
+        token = self.login()
+        if not token:
+            raise RuntimeError("Login failed - no token received")
+        resp = self._auth.session.get(invoices_url, headers=self._api_headers(token))
+        if not resp.ok:
+            raise RuntimeError(f"Invoices failed with status {resp.status_code}: {resp.text[:200]}")
+        return invoices_from_dict(resp.json())
 
-    def login(self) -> string:
+    def login(self) -> str:
         return self._auth.login()

--- a/custom_components/pgnig_gas_sensor/auth/__init__.py
+++ b/custom_components/pgnig_gas_sensor/auth/__init__.py
@@ -1,10 +1,12 @@
 """Authentication method abstraction for Orlen EBOK."""
 from __future__ import annotations
 
-import hashlib
+import secrets
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional
+
+import requests
 
 
 @dataclass
@@ -18,6 +20,11 @@ class AuthMethod(ABC):
     @property
     @abstractmethod
     def info(self) -> AuthMethodInfo:
+        pass
+
+    @property
+    @abstractmethod
+    def session(self) -> requests.Session:
         pass
 
     @abstractmethod
@@ -48,7 +55,7 @@ class AuthRegistry:
 
 
 def device_id(username: str) -> str:
-    return hashlib.md5(username.encode()).hexdigest()
+    return secrets.token_hex(16)
 
 
 from .api_login import ApiLoginAuth  # noqa: E402

--- a/custom_components/pgnig_gas_sensor/auth/__init__.py
+++ b/custom_components/pgnig_gas_sensor/auth/__init__.py
@@ -1,0 +1,55 @@
+"""Authentication method abstraction for Orlen EBOK."""
+from __future__ import annotations
+
+import hashlib
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class AuthMethodInfo:
+    id: str
+    name: str
+    description: str
+
+
+class AuthMethod(ABC):
+    @property
+    @abstractmethod
+    def info(self) -> AuthMethodInfo:
+        pass
+
+    @abstractmethod
+    def login(self) -> str:
+        pass
+
+
+class AuthRegistry:
+    _methods: dict[str, type[AuthMethod]] = {}
+
+    @classmethod
+    def register(cls, method_class: type[AuthMethod]) -> type[AuthMethod]:
+        instance = method_class("", "")
+        cls._methods[instance.info.id] = method_class
+        return method_class
+
+    @classmethod
+    def get(cls, method_id: str) -> Optional[type[AuthMethod]]:
+        return cls._methods.get(method_id)
+
+    @classmethod
+    def list(cls) -> list[AuthMethodInfo]:
+        return [m("", "").info for m in cls._methods.values()]
+
+    @classmethod
+    def get_ids(cls) -> list[str]:
+        return list(cls._methods.keys())
+
+
+def device_id(username: str) -> str:
+    return hashlib.md5(username.encode()).hexdigest()
+
+
+from .api_login import ApiLoginAuth  # noqa: E402
+from .orlen_id import OrlenIDAuth  # noqa: E402

--- a/custom_components/pgnig_gas_sensor/auth/api_login.py
+++ b/custom_components/pgnig_gas_sensor/auth/api_login.py
@@ -1,0 +1,34 @@
+"""Legacy API login strategy for Orlen EBOK."""
+import requests
+
+from . import AuthMethod, AuthMethodInfo, AuthRegistry, device_id
+
+login_url = "https://ebok.myorlen.pl/auth/login?api-version=3.0"
+headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+}
+
+
+@AuthRegistry.register
+class ApiLoginAuth(AuthMethod):
+    def __init__(self, username, password) -> None:
+        self.username = username
+        self.password = password
+
+    @property
+    def info(self) -> AuthMethodInfo:
+        return AuthMethodInfo(
+            id="api_login",
+            name="API Login (legacy)",
+            description="Legacy username/password login via API"
+        )
+
+    def login(self) -> str:
+        payload = {"identificator": self.username,
+                   "accessPin": self.password,
+                   "rememberLogin": "false",
+                   "DeviceId": device_id(self.username),
+                   "DeviceName": "Home Assistant: 99.9.999.99<br>",
+                   "DeviceType": "Web"}
+        return requests.request('POST', login_url, headers=headers, json=payload).json().get('Token')

--- a/custom_components/pgnig_gas_sensor/auth/api_login.py
+++ b/custom_components/pgnig_gas_sensor/auth/api_login.py
@@ -1,12 +1,30 @@
 """Legacy API login strategy for Orlen EBOK."""
+import logging
+
 import requests
 
 from . import AuthMethod, AuthMethodInfo, AuthRegistry, device_id
 
-login_url = "https://ebok.myorlen.pl/auth/login?api-version=3.0"
-headers = {
-    'Content-Type': 'application/json',
+_LOGGER = logging.getLogger(__name__)
+
+BASE_URL = "https://ebok.myorlen.pl"
+login_url = f"{BASE_URL}/auth/login?api-version=3.0"
+
+browser_headers = {
     'Accept': 'application/json',
+    'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
+    'Cache-Control': 'no-cache',
+    'Content-Type': 'application/json',
+    'Origin': BASE_URL,
+    'Pragma': 'no-cache',
+    'Referer': f'{BASE_URL}/',
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+    'sec-ch-ua': '"Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"macOS"',
+    'Sec-Fetch-Dest': 'empty',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Site': 'same-origin',
 }
 
 
@@ -15,6 +33,10 @@ class ApiLoginAuth(AuthMethod):
     def __init__(self, username, password) -> None:
         self.username = username
         self.password = password
+        self._device_id = device_id(username)
+        self._session = requests.Session()
+        self._session.headers.update(browser_headers)
+        self._session.cookies.set("pgnig-ebok-device-token", self._device_id)
 
     @property
     def info(self) -> AuthMethodInfo:
@@ -24,11 +46,33 @@ class ApiLoginAuth(AuthMethod):
             description="Legacy username/password login via API"
         )
 
+    def _init_session(self):
+        _LOGGER.debug("Initializing session with GET %s", BASE_URL)
+        resp = self._session.get(BASE_URL, timeout=30)
+        _LOGGER.debug("Session init status: %s, cookies: %s", resp.status_code, dict(self._session.cookies))
+
     def login(self) -> str:
+        self._init_session()
+
         payload = {"identificator": self.username,
                    "accessPin": self.password,
-                   "rememberLogin": "false",
-                   "DeviceId": device_id(self.username),
-                   "DeviceName": "Home Assistant: 99.9.999.99<br>",
+                   "rememberLogin": False,
+                   "DeviceId": self._device_id,
+                   "DeviceName": "Home Assistant",
                    "DeviceType": "Web"}
-        return requests.request('POST', login_url, headers=headers, json=payload).json().get('Token')
+        response = self._session.post(login_url, json=payload, timeout=30)
+        _LOGGER.debug("Login response status: %s, body: %s", response.status_code, response.text[:500])
+        if not response.ok:
+            raise RuntimeError(f"Login failed with status {response.status_code}: {response.text[:200]}")
+        try:
+            data = response.json()
+        except ValueError as e:
+            raise RuntimeError(
+                f"Login returned non-JSON response (status {response.status_code}). "
+                f"Headers: {dict(response.headers)}. "
+                f"Body preview: {response.text[:500]}"
+            ) from e
+        token = data.get('Token')
+        if not token:
+            raise RuntimeError(f"Login response missing 'Token' field: {data}")
+        return token

--- a/custom_components/pgnig_gas_sensor/auth/api_login.py
+++ b/custom_components/pgnig_gas_sensor/auth/api_login.py
@@ -37,6 +37,11 @@ class ApiLoginAuth(AuthMethod):
         self._session = requests.Session()
         self._session.headers.update(browser_headers)
         self._session.cookies.set("pgnig-ebok-device-token", self._device_id)
+        self._cached_token: str = ""
+
+    @property
+    def session(self) -> requests.Session:
+        return self._session
 
     @property
     def info(self) -> AuthMethodInfo:
@@ -52,6 +57,10 @@ class ApiLoginAuth(AuthMethod):
         _LOGGER.debug("Session init status: %s, cookies: %s", resp.status_code, dict(self._session.cookies))
 
     def login(self) -> str:
+        if self._cached_token:
+            _LOGGER.debug("Using cached auth token")
+            return self._cached_token
+
         self._init_session()
 
         payload = {"identificator": self.username,
@@ -75,4 +84,5 @@ class ApiLoginAuth(AuthMethod):
         token = data.get('Token')
         if not token:
             raise RuntimeError(f"Login response missing 'Token' field: {data}")
+        self._cached_token = token
         return token

--- a/custom_components/pgnig_gas_sensor/auth/orlen_id.py
+++ b/custom_components/pgnig_gas_sensor/auth/orlen_id.py
@@ -36,6 +36,11 @@ class OrlenIDAuth(AuthMethod):
         self._session = requests.Session()
         self._session.headers.update(browser_headers)
         self._session.cookies.set("pgnig-ebok-device-token", self._device_id)
+        self._cached_token: str = ""
+
+    @property
+    def session(self) -> requests.Session:
+        return self._session
 
     @property
     def info(self) -> AuthMethodInfo:
@@ -51,6 +56,10 @@ class OrlenIDAuth(AuthMethod):
         _LOGGER.debug("Session init status: %s, cookies: %s", resp.status_code, dict(self._session.cookies))
 
     def login(self) -> str:
+        if self._cached_token:
+            _LOGGER.debug("Using cached auth token")
+            return self._cached_token
+
         self._init_session()
 
         init_url = f'{BASE_URL}/auth/oid/init-login?api-version=3.0'
@@ -83,7 +92,11 @@ class OrlenIDAuth(AuthMethod):
 
             if f"{BASE_URL}/home" in final_response.url:
                 auth_token_url = f'{BASE_URL}/auth/get-auth-token?deviceId={self._device_id}&api-version=3.0'
-                res_auth = self._session.get(auth_token_url, timeout=30)
+                res_auth = self._session.get(auth_token_url, headers={
+                    'Accept': 'application/json, text/plain, */*',
+                    'Referer': f'{BASE_URL}/home',
+                }, timeout=30)
                 if res_auth.status_code == 200:
-                    return res_auth.json().get('Token')
+                    self._cached_token = res_auth.json().get('Token', "")
+                    return self._cached_token
         return ""

--- a/custom_components/pgnig_gas_sensor/auth/orlen_id.py
+++ b/custom_components/pgnig_gas_sensor/auth/orlen_id.py
@@ -1,0 +1,60 @@
+"""OrlenID OID login strategy for Orlen EBOK."""
+import re
+
+import requests
+
+from . import AuthMethod, AuthMethodInfo, AuthRegistry, device_id
+
+
+@AuthRegistry.register
+class OrlenIDAuth(AuthMethod):
+    def __init__(self, username, password) -> None:
+        self.username = username
+        self.password = password
+
+    @property
+    def info(self) -> AuthMethodInfo:
+        return AuthMethodInfo(
+            id="orlen_id",
+            name="OrlenID",
+            description="OrlenID OID login"
+        )
+
+    def login(self) -> str:
+        init_url = 'https://ebok.myorlen.pl/auth/oid/init-login?api-version=3.0'
+
+        init_device_id = device_id(self.username)
+        session = requests.Session()
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8'
+        }
+        init_data = {
+            "DeviceId": init_device_id,
+            "DeviceType": "Web",
+            "DeviceName": "HomeAssistant wersja: 0.1",
+            "LightweightRedirectUrl": "https://ebok.myorlen.pl/?show=modal",
+            "FinalizeRegistrationRedirectUrl": "https://ebok.myorlen.pl/aktywuj-oid/"
+        }
+
+        response_init = session.post(init_url, json=init_data, headers={'Content-Type': 'application/json'})
+        redirect_url = response_init.json().get('RedirectUrl')
+        response_page = session.get(redirect_url, headers=headers)
+        match = re.search(r'action="([^"]+)"', response_page.text)
+
+        if match:
+            post_url = match.group(1).replace('&amp;', '&')
+            payload = {
+                'username': self.username,
+                'password': self.password,
+                'credentialId': ''
+            }
+            final_response = session.post(post_url, data=payload, headers=headers)
+
+            if "https://ebok.myorlen.pl/home" in final_response.url:
+                auth_token_url = f'https://ebok.myorlen.pl/auth/get-auth-token?deviceId={init_data["DeviceId"]}&api-version=3.0'
+                headers.update({'Referer': 'https://ebok.myorlen.pl/'})
+                res_auth = session.get(auth_token_url, headers=headers)
+                if res_auth.status_code == 200:
+                    return res_auth.json().get('Token')
+        return ""

--- a/custom_components/pgnig_gas_sensor/auth/orlen_id.py
+++ b/custom_components/pgnig_gas_sensor/auth/orlen_id.py
@@ -1,9 +1,30 @@
 """OrlenID OID login strategy for Orlen EBOK."""
+import logging
 import re
 
 import requests
 
 from . import AuthMethod, AuthMethodInfo, AuthRegistry, device_id
+
+_LOGGER = logging.getLogger(__name__)
+
+BASE_URL = "https://ebok.myorlen.pl"
+
+browser_headers = {
+    'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
+    'Cache-Control': 'no-cache',
+    'Content-Type': 'application/json',
+    'Origin': BASE_URL,
+    'Pragma': 'no-cache',
+    'Referer': f'{BASE_URL}/',
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+    'sec-ch-ua': '"Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"macOS"',
+    'Sec-Fetch-Dest': 'empty',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Site': 'same-origin',
+}
 
 
 @AuthRegistry.register
@@ -11,6 +32,10 @@ class OrlenIDAuth(AuthMethod):
     def __init__(self, username, password) -> None:
         self.username = username
         self.password = password
+        self._device_id = device_id(username)
+        self._session = requests.Session()
+        self._session.headers.update(browser_headers)
+        self._session.cookies.set("pgnig-ebok-device-token", self._device_id)
 
     @property
     def info(self) -> AuthMethodInfo:
@@ -20,26 +45,28 @@ class OrlenIDAuth(AuthMethod):
             description="OrlenID OID login"
         )
 
-    def login(self) -> str:
-        init_url = 'https://ebok.myorlen.pl/auth/oid/init-login?api-version=3.0'
+    def _init_session(self):
+        _LOGGER.debug("Initializing session with GET %s", BASE_URL)
+        resp = self._session.get(BASE_URL, timeout=30)
+        _LOGGER.debug("Session init status: %s, cookies: %s", resp.status_code, dict(self._session.cookies))
 
-        init_device_id = device_id(self.username)
-        session = requests.Session()
-        headers = {
-            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36',
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8'
-        }
+    def login(self) -> str:
+        self._init_session()
+
+        init_url = f'{BASE_URL}/auth/oid/init-login?api-version=3.0'
         init_data = {
-            "DeviceId": init_device_id,
+            "DeviceId": self._device_id,
             "DeviceType": "Web",
             "DeviceName": "HomeAssistant wersja: 0.1",
-            "LightweightRedirectUrl": "https://ebok.myorlen.pl/?show=modal",
-            "FinalizeRegistrationRedirectUrl": "https://ebok.myorlen.pl/aktywuj-oid/"
+            "LightweightRedirectUrl": f"{BASE_URL}/?show=modal",
+            "FinalizeRegistrationRedirectUrl": f"{BASE_URL}/aktywuj-oid/"
         }
 
-        response_init = session.post(init_url, json=init_data, headers={'Content-Type': 'application/json'})
+        response_init = self._session.post(init_url, json=init_data, timeout=30)
+        _LOGGER.debug("Init login status: %s", response_init.status_code)
         redirect_url = response_init.json().get('RedirectUrl')
-        response_page = session.get(redirect_url, headers=headers)
+
+        response_page = self._session.get(redirect_url, timeout=30)
         match = re.search(r'action="([^"]+)"', response_page.text)
 
         if match:
@@ -49,12 +76,14 @@ class OrlenIDAuth(AuthMethod):
                 'password': self.password,
                 'credentialId': ''
             }
-            final_response = session.post(post_url, data=payload, headers=headers)
+            final_response = self._session.post(post_url, data=payload, headers={
+                'Referer': redirect_url,
+                'Content-Type': 'application/x-www-form-urlencoded',
+            }, timeout=30)
 
-            if "https://ebok.myorlen.pl/home" in final_response.url:
-                auth_token_url = f'https://ebok.myorlen.pl/auth/get-auth-token?deviceId={init_data["DeviceId"]}&api-version=3.0'
-                headers.update({'Referer': 'https://ebok.myorlen.pl/'})
-                res_auth = session.get(auth_token_url, headers=headers)
+            if f"{BASE_URL}/home" in final_response.url:
+                auth_token_url = f'{BASE_URL}/auth/get-auth-token?deviceId={self._device_id}&api-version=3.0'
+                res_auth = self._session.get(auth_token_url, timeout=30)
                 if res_auth.status_code == 200:
                     return res_auth.json().get('Token')
         return ""

--- a/custom_components/pgnig_gas_sensor/button.py
+++ b/custom_components/pgnig_gas_sensor/button.py
@@ -9,7 +9,7 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
 from .PgnigApi import PgnigApi
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,8 +23,9 @@ async def async_setup_entry(
     """Set up the PGNIG button."""
     username = config_entry.data.get(CONF_USERNAME)
     password = config_entry.data.get(CONF_PASSWORD)
+    auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
 
-    api = PgnigApi(username, password)
+    api = PgnigApi(username, password, auth_method)
     meter_list = await hass.async_add_executor_job(api.meterList)
 
     buttons = []

--- a/custom_components/pgnig_gas_sensor/config_flow.py
+++ b/custom_components/pgnig_gas_sensor/config_flow.py
@@ -9,39 +9,15 @@ from .auth import AuthRegistry
 from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
 from .PgnigApi import PgnigApi
 
-AUTH_SCHEMA = vol.Schema({
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-})
-
 
 class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_config):
         return self.async_abort(reason="one_instance_at_a_time_please")
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None):
-        methods = AuthRegistry.list()
-
-        if len(methods) == 1:
-            return await self.async_step_credentials({
-                CONF_AUTH_METHOD: methods[0].id,
-                **(user_input or {}),
-            })
-
-        if user_input is not None and CONF_AUTH_METHOD in user_input:
-            return await self.async_step_credentials(user_input)
-
-        options = [(m.id, m.name) for m in methods]
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema({
-                vol.Required(CONF_AUTH_METHOD): vol.In(dict(options)),
-            }),
-        )
-
-    async def async_step_credentials(self, user_input: Optional[Dict[str, Any]] = None):
         errors: Dict[str, str] = {}
         description_placeholders: Dict[str, str] = {"error_info": ""}
+        methods = AuthRegistry.list()
 
         if user_input is not None:
             auth_method = user_input.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
@@ -61,19 +37,15 @@ class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors = {"base": "verify_connection_failed"}
                 description_placeholders = {"error_info": "EBOK Login Failed"}
 
-        step_data = {}
-        if user_input and CONF_AUTH_METHOD in user_input:
-            step_data[CONF_AUTH_METHOD] = user_input[CONF_AUTH_METHOD]
-
-        schema_dict: Dict[str, Any] = {
-            vol.Required(CONF_USERNAME): cv.string,
-            vol.Required(CONF_PASSWORD): cv.string,
-        }
-        if CONF_AUTH_METHOD in step_data:
-            schema_dict[CONF_AUTH_METHOD] = vol.Hidden()
+        schema_dict: Dict[str, Any] = {}
+        if len(methods) > 1:
+            options = [(m.id, m.name) for m in methods]
+            schema_dict[vol.Required(CONF_AUTH_METHOD)] = vol.In(dict(options))
+        schema_dict[vol.Required(CONF_USERNAME)] = cv.string
+        schema_dict[vol.Required(CONF_PASSWORD)] = cv.string
 
         return self.async_show_form(
-            step_id="credentials",
+            step_id="user",
             data_schema=vol.Schema(schema_dict),
             errors=errors,
             description_placeholders=description_placeholders,
@@ -82,38 +54,46 @@ class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(self, user_input: Optional[Dict[str, Any]] = None):
         errors: Dict[str, str] = {}
         description_placeholders: Dict[str, str] = {"error_info": ""}
+        methods = AuthRegistry.list()
 
         entry_id = self.context.get("entry_id")
+        config_entry = self.hass.config_entries.async_get_entry(entry_id) if entry_id else None
 
-        if user_input is not None and entry_id:
-            config_entry = self.hass.config_entries.async_get_entry(entry_id)
-            if config_entry:
-                auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
-                try:
-                    api = PgnigApi(
-                        user_input[CONF_USERNAME],
-                        user_input[CONF_PASSWORD],
-                        auth_method,
-                    )
-                    await self.hass.async_add_executor_job(api.login)
+        if user_input is not None and config_entry:
+            auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
+            try:
+                api = PgnigApi(
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                    auth_method,
+                )
+                await self.hass.async_add_executor_job(api.login)
 
-                    self.hass.config_entries.async_update_entry(
-                        config_entry,
-                        data={
-                            **config_entry.data,
-                            CONF_USERNAME: user_input[CONF_USERNAME],
-                            CONF_PASSWORD: user_input[CONF_PASSWORD],
-                        },
-                    )
-                    await self.hass.config_entries.async_reload(entry_id)
-                    return self.async_abort(reason="reauth_successful")
-                except Exception:
-                    errors["base"] = "verify_connection_failed"
-                    description_placeholders["error_info"] = "Login Failed"
+                self.hass.config_entries.async_update_entry(
+                    config_entry,
+                    data={
+                        **config_entry.data,
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+                await self.hass.config_entries.async_reload(entry_id)
+                return self.async_abort(reason="reauth_successful")
+            except Exception:
+                errors["base"] = "verify_connection_failed"
+                description_placeholders["error_info"] = "Login Failed"
+
+        schema_dict: Dict[str, Any] = {}
+        if len(methods) > 1 and config_entry:
+            current_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
+            options = [(m.id, m.name) for m in methods]
+            schema_dict[vol.Required(CONF_AUTH_METHOD, default=current_method)] = vol.In(dict(options))
+        schema_dict[vol.Required(CONF_USERNAME)] = cv.string
+        schema_dict[vol.Required(CONF_PASSWORD)] = cv.string
 
         return self.async_show_form(
             step_id="reauth",
-            data_schema=AUTH_SCHEMA,
+            data_schema=vol.Schema(schema_dict),
             errors=errors,
             description_placeholders=description_placeholders,
         )

--- a/custom_components/pgnig_gas_sensor/config_flow.py
+++ b/custom_components/pgnig_gas_sensor/config_flow.py
@@ -5,7 +5,9 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
-from custom_components.pgnig_gas_sensor.PgnigApi import PgnigApi
+from .auth import AuthRegistry
+from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
+from .PgnigApi import PgnigApi
 
 AUTH_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): cv.string,
@@ -13,23 +15,155 @@ AUTH_SCHEMA = vol.Schema({
 })
 
 
-class PGNIGGasConfigFlow(ConfigFlow, domain="pgnig_gas_sensor"):
-    """Example config flow."""
-
+class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_config):
         return self.async_abort(reason="one_instance_at_a_time_please")
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None):
+        methods = AuthRegistry.list()
+
+        if len(methods) == 1:
+            return await self.async_step_credentials({
+                CONF_AUTH_METHOD: methods[0].id,
+                **(user_input or {}),
+            })
+
+        if user_input is not None and CONF_AUTH_METHOD in user_input:
+            return await self.async_step_credentials(user_input)
+
+        options = [(m.id, m.name) for m in methods]
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({
+                vol.Required(CONF_AUTH_METHOD): vol.In(dict(options)),
+            }),
+        )
+
+    async def async_step_credentials(self, user_input: Optional[Dict[str, Any]] = None):
         errors: Dict[str, str] = {}
-        description_placeholders = {"error_info": ""}
+        description_placeholders: Dict[str, str] = {"error_info": ""}
+
         if user_input is not None:
-            api = PgnigApi(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
+            auth_method = user_input.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
+            username = user_input.get(CONF_USERNAME)
+            password = user_input.get(CONF_PASSWORD)
+
+            api = PgnigApi(username, password, auth_method)
             try:
                 await self.hass.async_add_executor_job(api.login)
-                return self.async_create_entry(title="Pgnig sensor", data=user_input)
-            except Exception as e:
-                errors = {"login_failed": "verify_connection_failed"}
+                data = {
+                    CONF_USERNAME: username,
+                    CONF_PASSWORD: password,
+                    CONF_AUTH_METHOD: auth_method,
+                }
+                return self.async_create_entry(title="Pgnig sensor", data=data)
+            except Exception:
+                errors = {"base": "verify_connection_failed"}
                 description_placeholders = {"error_info": "EBOK Login Failed"}
+
+        step_data = {}
+        if user_input and CONF_AUTH_METHOD in user_input:
+            step_data[CONF_AUTH_METHOD] = user_input[CONF_AUTH_METHOD]
+
+        schema_dict: Dict[str, Any] = {
+            vol.Required(CONF_USERNAME): cv.string,
+            vol.Required(CONF_PASSWORD): cv.string,
+        }
+        if CONF_AUTH_METHOD in step_data:
+            schema_dict[CONF_AUTH_METHOD] = vol.Hidden()
+
         return self.async_show_form(
-            step_id="user", data_schema=AUTH_SCHEMA, errors=errors, description_placeholders=description_placeholders
+            step_id="credentials",
+            data_schema=vol.Schema(schema_dict),
+            errors=errors,
+            description_placeholders=description_placeholders,
+        )
+
+    async def async_step_reauth(self, user_input: Optional[Dict[str, Any]] = None):
+        errors: Dict[str, str] = {}
+        description_placeholders: Dict[str, str] = {"error_info": ""}
+
+        entry_id = self.context.get("entry_id")
+
+        if user_input is not None and entry_id:
+            config_entry = self.hass.config_entries.async_get_entry(entry_id)
+            if config_entry:
+                auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
+                try:
+                    api = PgnigApi(
+                        user_input[CONF_USERNAME],
+                        user_input[CONF_PASSWORD],
+                        auth_method,
+                    )
+                    await self.hass.async_add_executor_job(api.login)
+
+                    self.hass.config_entries.async_update_entry(
+                        config_entry,
+                        data={
+                            **config_entry.data,
+                            CONF_USERNAME: user_input[CONF_USERNAME],
+                            CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        },
+                    )
+                    await self.hass.config_entries.async_reload(entry_id)
+                    return self.async_abort(reason="reauth_successful")
+                except Exception:
+                    errors["base"] = "verify_connection_failed"
+                    description_placeholders["error_info"] = "Login Failed"
+
+        return self.async_show_form(
+            step_id="reauth",
+            data_schema=AUTH_SCHEMA,
+            errors=errors,
+            description_placeholders=description_placeholders,
+        )
+
+    async def async_step_reconfigure(self, user_input: Optional[Dict[str, Any]] = None):
+        methods = AuthRegistry.list()
+        entry_id = self.context.get("entry_id")
+        config_entry = self.hass.config_entries.async_get_entry(entry_id) if entry_id else None
+
+        if config_entry is None:
+            return self.async_abort(reason="no_config_entry")
+
+        if user_input is not None:
+            auth_method = user_input.get(CONF_AUTH_METHOD, config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD))
+            username = user_input.get(CONF_USERNAME)
+            password = user_input.get(CONF_PASSWORD)
+
+            try:
+                api = PgnigApi(username, password, auth_method)
+                await self.hass.async_add_executor_job(api.login)
+
+                self.hass.config_entries.async_update_entry(
+                    config_entry,
+                    data={
+                        CONF_USERNAME: username,
+                        CONF_PASSWORD: password,
+                        CONF_AUTH_METHOD: auth_method,
+                    },
+                )
+                await self.hass.config_entries.async_reload(config_entry.entry_id)
+
+                return self.async_abort(reason="reconfigure_successful")
+            except Exception:
+                errors = {"base": "verify_connection_failed"}
+                description_placeholders = {"error_info": "Login Failed"}
+        else:
+            errors = {}
+            description_placeholders = {"error_info": ""}
+
+        current_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
+        schema_dict: Dict[str, Any] = {}
+        if len(methods) > 1:
+            options = [(m.id, m.name) for m in methods]
+            schema_dict[vol.Required(CONF_AUTH_METHOD, default=current_method)] = vol.In(dict(options))
+        schema_dict[vol.Required(CONF_USERNAME)] = cv.string
+        schema_dict[vol.Required(CONF_PASSWORD)] = cv.string
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(schema_dict),
+            errors=errors,
+            description_placeholders=description_placeholders,
         )

--- a/custom_components/pgnig_gas_sensor/const.py
+++ b/custom_components/pgnig_gas_sensor/const.py
@@ -1,3 +1,5 @@
 """Constants for PGNIG Gas Sensor."""
 
 DOMAIN = "pgnig_gas_sensor"
+CONF_AUTH_METHOD = "auth_method"
+DEFAULT_AUTH_METHOD = "api_login"

--- a/custom_components/pgnig_gas_sensor/diagnostics.py
+++ b/custom_components/pgnig_gas_sensor/diagnostics.py
@@ -8,7 +8,7 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
 from .PgnigApi import PgnigApi
 from .Invoices import InvoicesList
 from .PpgReadingForMeter import MeterReading
@@ -25,8 +25,9 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     username = config_entry.data.get("username")
     password = config_entry.data.get("password")
+    auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
 
-    api = PgnigApi(username, password)
+    api = PgnigApi(username, password, auth_method)
 
     meters = await hass.async_add_executor_job(api.meterList)
     invoices = await hass.async_add_executor_job(api.invoices)

--- a/custom_components/pgnig_gas_sensor/sensor.py
+++ b/custom_components/pgnig_gas_sensor/sensor.py
@@ -132,6 +132,7 @@ class PgnigInvoiceSensor(SensorEntity):
     def __init__(self, hass, api: PgnigApi, meter_id: string, id_local: int) -> None:
         self._attr_native_unit_of_measurement = "PLN"
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._state: MeterReading | None = None
         self.hass = hass
         self.api = api
@@ -204,6 +205,7 @@ class PgnigCostTrackingSensor(SensorEntity):
     def __init__(self, hass, api: PgnigApi, meter_id: string, id_local: int) -> None:
         self._attr_native_unit_of_measurement = "PLN/m³"
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._state: InvoicesList | None = None
         self.hass = hass
         self.api = api

--- a/custom_components/pgnig_gas_sensor/sensor.py
+++ b/custom_components/pgnig_gas_sensor/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from .Invoices import InvoicesList
 from .PgnigApi import PgnigApi
 from .PpgReadingForMeter import MeterReading
+from .const import CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -34,7 +35,8 @@ async def async_setup_entry(
 ):
     user = config_entry.data[CONF_USERNAME]
     password = config_entry.data[CONF_PASSWORD]
-    api = PgnigApi(user, password)
+    auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
+    api = PgnigApi(user, password, auth_method)
     try:
         pgps = await hass.async_add_executor_job(api.meterList)
     except Exception:
@@ -55,7 +57,7 @@ async def async_setup_platform(
         async_add_entities: Callable,
         discovery_info: Optional[DiscoveryInfoType] = None,
 ) -> None:
-    api = PgnigApi(config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
+    api = PgnigApi(config.get(CONF_USERNAME), config.get(CONF_PASSWORD), DEFAULT_AUTH_METHOD)
     try:
         pgps = await hass.async_add_executor_job(api.meterList)
     except Exception:

--- a/custom_components/pgnig_gas_sensor/sensor.py
+++ b/custom_components/pgnig_gas_sensor/sensor.py
@@ -39,8 +39,9 @@ async def async_setup_entry(
     api = PgnigApi(user, password, auth_method)
     try:
         pgps = await hass.async_add_executor_job(api.meterList)
-    except Exception:
-        raise ValueError
+    except Exception as err:
+        _LOGGER.error("Failed to set up PGNiG sensor: %s", err)
+        raise
 
     for x in pgps.ppg_list:
         meter_id = x.meter_number
@@ -60,8 +61,9 @@ async def async_setup_platform(
     api = PgnigApi(config.get(CONF_USERNAME), config.get(CONF_PASSWORD), DEFAULT_AUTH_METHOD)
     try:
         pgps = await hass.async_add_executor_job(api.meterList)
-    except Exception:
-        raise ValueError
+    except Exception as err:
+        _LOGGER.error("Failed to set up PGNiG sensor: %s", err)
+        raise
 
     for x in pgps.ppg_list:
         async_add_entities(

--- a/custom_components/pgnig_gas_sensor/strings.json
+++ b/custom_components/pgnig_gas_sensor/strings.json
@@ -3,9 +3,33 @@
   "config": {
     "step": {
       "user": {
+        "title": "Select login method",
+        "description": "Choose how to log in to your Orlen EBOK account.",
+        "data": {
+          "auth_method": "Login method"
+        }
+      },
+      "credentials": {
         "title": "Enter the credentials to your Orlen EBOK",
         "description": "This integration will add sensors to get gas usage data from Orlen Sensor. \n\n\n\n {error_info}",
         "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "reauth": {
+        "title": "Update credentials for Orlen EBOK",
+        "description": "Your login credentials are invalid. Please update them. \n\n\n\n {error_info}",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Orlen gas sensor",
+        "description": "Update login method or credentials. \n\n\n\n {error_info}",
+        "data": {
+          "auth_method": "Login method",
           "username": "Username",
           "password": "Password"
         }
@@ -13,6 +37,12 @@
     },
     "error": {
       "verify_connection_failed": "Login failed!"
+    },
+    "abort": {
+      "reauth_successful": "Credentials updated successfully",
+      "reconfigure_successful": "Configuration updated successfully",
+      "no_config_entry": "No configuration entry found",
+      "one_instance_at_a_time_please": "Only one instance is allowed"
     }
   }
 }

--- a/custom_components/pgnig_gas_sensor/translations/en.json
+++ b/custom_components/pgnig_gas_sensor/translations/en.json
@@ -3,9 +3,33 @@
   "config": {
     "step": {
       "user": {
+        "title": "Select login method",
+        "description": "Choose how to log in to your Orlen EBOK account.",
+        "data": {
+          "auth_method": "Login method"
+        }
+      },
+      "credentials": {
         "title": "Enter the credentials to your Orlen EBOK",
         "description": "This integration will add sensors to get gas usage data from Orlen Sensor. \n\n\n\n {error_info}",
         "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "reauth": {
+        "title": "Update credentials for Orlen EBOK",
+        "description": "Your login credentials are invalid. Please update them. \n\n\n\n {error_info}",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Orlen gas sensor",
+        "description": "Update login method or credentials. \n\n\n\n {error_info}",
+        "data": {
+          "auth_method": "Login method",
           "username": "Username",
           "password": "Password"
         }
@@ -13,6 +37,12 @@
     },
     "error": {
       "verify_connection_failed": "Login failed!"
+    },
+    "abort": {
+      "reauth_successful": "Credentials updated successfully",
+      "reconfigure_successful": "Configuration updated successfully",
+      "no_config_entry": "No configuration entry found",
+      "one_instance_at_a_time_please": "Only one instance is allowed"
     }
   }
 }

--- a/custom_components/pgnig_gas_sensor/translations/pl.json
+++ b/custom_components/pgnig_gas_sensor/translations/pl.json
@@ -3,9 +3,33 @@
   "config": {
     "step": {
       "user": {
+        "title": "Wybierz metodę logowania",
+        "description": "Wybierz jak logować się do swojego konta Orlen EBOK.",
+        "data": {
+          "auth_method": "Metoda logowania"
+        }
+      },
+      "credentials": {
         "title": "Wpisz swoje dane autoryzacyjne do Orlen EBOK",
         "description": "Ta integracja dodaje sensory uzycia gazu na podstawie odczytów z EBOKu Orlen.\n\n\n\n {error_info}",
         "data": {
+          "username": "Login",
+          "password": "Hasło"
+        }
+      },
+      "reauth": {
+        "title": "Zaktualizuj dane logowania do Orlen EBOK",
+        "description": "Twoje dane logowania są nieprawidłowe. Zaktualizuj je. \n\n\n\n {error_info}",
+        "data": {
+          "username": "Login",
+          "password": "Hasło"
+        }
+      },
+      "reconfigure": {
+        "title": "Zmień konfigurację sensora gazu Orlen",
+        "description": "Zaktualizuj metodę logowania lub dane autoryzacyjne. \n\n\n\n {error_info}",
+        "data": {
+          "auth_method": "Metoda logowania",
           "username": "Login",
           "password": "Hasło"
         }
@@ -13,6 +37,12 @@
     },
     "error": {
       "verify_connection_failed": "Logowanie nie powiodło się!"
+    },
+    "abort": {
+      "reauth_successful": "Dane logowania zaktualizowane pomyślnie",
+      "reconfigure_successful": "Konfiguracja zaktualizowana pomyślnie",
+      "no_config_entry": "Nie znaleziono wpisu konfiguracji",
+      "one_instance_at_a_time_please": "Dozwolona jest tylko jedna instancja"
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,9 @@
 """Global fixtures for pgnig_sensor integration."""
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+)
+
+
+# The `enable_custom_integrations` fixture is provided by
+# pytest-homeassistant-custom-component plugin.
+# Individual test files should request it when needed.

--- a/tests/test_api_login.py
+++ b/tests/test_api_login.py
@@ -1,0 +1,89 @@
+"""Tests for ApiLoginAuth auth method with mocked HTTP."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from custom_components.pgnig_gas_sensor.auth import AuthRegistry
+
+
+def _make_mock_response(json_data=None, status_code=200, text=""):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.text = text
+    resp.json.return_value = json_data or {}
+    resp.headers = {"Content-Type": "application/json"}
+    return resp
+
+
+@pytest.fixture
+def auth():
+    cls = AuthRegistry.get("api_login")
+    return cls("testuser", "testpass")
+
+
+def test_init_sets_session_and_cookies(auth):
+    assert auth._session is not None
+    assert isinstance(auth._session, requests.Session)
+    assert auth._session.headers.get("User-Agent") is not None
+    assert auth._session.cookies.get("pgnig-ebok-device-token")
+    assert auth._cached_token == ""
+
+
+def test_session_property(auth):
+    assert auth.session is auth._session
+
+
+def test_info(auth):
+    info = auth.info
+    assert info.id == "api_login"
+    assert info.name == "API Login (legacy)"
+
+
+def test_login_returns_cached_token(auth):
+    auth._cached_token = "cached-token-123"
+    with patch.object(auth, "_init_session") as mock_init:
+        token = auth.login()
+        assert token == "cached-token-123"
+        mock_init.assert_not_called()
+
+
+def test_login_success(auth):
+    with patch.object(auth, "_session") as mock_session:
+        mock_session.get.return_value = _make_mock_response(status_code=200)
+        mock_session.post.return_value = _make_mock_response(
+            {"Token": "real-token-abc"}, status_code=200
+        )
+        token = auth.login()
+        assert token == "real-token-abc"
+        assert auth._cached_token == "real-token-abc"
+
+
+def test_login_raises_on_http_error(auth):
+    with patch.object(auth, "_session") as mock_session:
+        mock_session.get.return_value = _make_mock_response(status_code=200)
+        mock_session.post.return_value = _make_mock_response(status_code=401)
+        with pytest.raises(RuntimeError, match="Login failed with status 401"):
+            auth.login()
+
+
+def test_login_raises_on_non_json(auth):
+    with patch.object(auth, "_session") as mock_session:
+        mock_session.get.return_value = _make_mock_response(status_code=200)
+        resp = _make_mock_response(status_code=200)
+        resp.json.side_effect = ValueError("Not JSON")
+        resp.text = "not json"
+        mock_session.post.return_value = resp
+        with pytest.raises(RuntimeError, match="non-JSON response"):
+            auth.login()
+
+
+def test_login_raises_on_missing_token(auth):
+    with patch.object(auth, "_session") as mock_session:
+        mock_session.get.return_value = _make_mock_response(status_code=200)
+        mock_session.post.return_value = _make_mock_response(
+            {"NotToken": "abc"}, status_code=200
+        )
+        with pytest.raises(RuntimeError, match="missing 'Token' field"):
+            auth.login()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,61 @@
+"""Tests for auth module: AuthRegistry, AuthMethod, device_id."""
+import re
+
+from custom_components.pgnig_gas_sensor.auth import (
+    AuthRegistry,
+    AuthMethod,
+    device_id,
+    AuthMethodInfo,
+)
+
+
+def test_device_id_format():
+    result = device_id("test@example.com")
+    assert re.match(r"^[0-9a-f]{32}$", result)
+
+
+def test_device_id_is_random():
+    a = device_id("same@user.com")
+    b = device_id("same@user.com")
+    assert a != b
+
+
+def test_auth_registry_contains_registered_methods():
+    ids = AuthRegistry.get_ids()
+    assert "api_login" in ids
+    assert "orlen_id" in ids
+
+
+def test_auth_registry_get_known():
+    cls = AuthRegistry.get("api_login")
+    assert cls is not None
+    assert issubclass(cls, AuthMethod)
+
+
+def test_auth_registry_get_unknown():
+    assert AuthRegistry.get("nonexistent_method") is None
+
+
+def test_auth_registry_list():
+    infos = AuthRegistry.list()
+    assert len(infos) >= 2
+    info_ids = [i.id for i in infos]
+    assert "api_login" in info_ids
+    assert "orlen_id" in info_ids
+    for info in infos:
+        assert isinstance(info, AuthMethodInfo)
+
+
+def test_auth_registry_get_ids():
+    ids = AuthRegistry.get_ids()
+    assert "api_login" in ids
+    assert "orlen_id" in ids
+    assert len(ids) >= 2
+
+
+def test_auth_method_abc_cannot_instantiate():
+    try:
+        AuthMethod()
+        assert False, "Should have raised TypeError"
+    except TypeError:
+        pass

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,82 @@
+"""Tests for PGNIG button entity."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.pgnig_gas_sensor.button import (
+    PgnigRefreshButton,
+    async_setup_entry,
+)
+from custom_components.pgnig_gas_sensor.const import DOMAIN
+from custom_components.pgnig_gas_sensor.PgpList import PpgList, PpgListElement
+
+
+@pytest.fixture
+def mock_api():
+    api = MagicMock()
+    api.meterList.return_value = PpgList(
+        ppg_list=[
+            PpgListElement(
+                id_ppg="1", meter_number="METER1", contract_number="C1",
+                has_t12=True, reading_added=True, tariff="T1",
+                has_history=True, type="G", id_local=1,
+                client_number=100, installation_number="INST1",
+                color="red", agreement_name="Main",
+                can_create_home_assistant=True, add_reading_mode="auto",
+                is_in_migration=False, is_in_migration_rk=False,
+                is_in_migration_rw=False, is_company=False,
+            ),
+        ],
+        code=0, message=None, display_to_end_user=False,
+        end_user_message=None,
+        token_expire_date="2026-06-01T00:00:00",
+        token_expire_date_utc="2026-06-01T00:00:00",
+    )
+    return api
+
+
+def test_button_entity_attributes(mock_api):
+    button = PgnigRefreshButton(
+        MagicMock(), mock_api, "METER1", 1
+    )
+    assert button.unique_id == "pgnig_refresh_METER1_1"
+    assert button._attr_has_entity_name is True
+    assert button._attr_translation_key == "refresh_data"
+    assert button.device_info is not None
+    assert button.device_info["identifiers"] == {(DOMAIN, "METER1")}
+
+
+async def test_button_press_calls_meter_list(mock_api):
+    button = PgnigRefreshButton(
+        MagicMock(), mock_api, "METER1", 1
+    )
+
+    async def executor_job(fn, *args):
+        return fn(*args)
+
+    button.hass.async_add_executor_job = executor_job
+    await button.async_press()
+    mock_api.meterList.assert_called_once()
+
+
+async def test_async_setup_entry_creates_buttons(hass: HomeAssistant, mock_api):
+    config_entry = MagicMock()
+    config_entry.data = {
+        "username": "user",
+        "password": "pass",
+        "auth_method": "api_login",
+    }
+
+    async_add_entities = MagicMock()
+
+    with patch(
+        "custom_components.pgnig_gas_sensor.button.PgnigApi",
+        return_value=mock_api,
+    ):
+        await async_setup_entry(hass, config_entry, async_add_entities)
+        async_add_entities.assert_called_once()
+        buttons = async_add_entities.call_args[0][0]
+        assert len(buttons) == 1
+        assert isinstance(buttons[0], PgnigRefreshButton)
+        assert buttons[0].meter_id == "METER1"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,258 @@
+"""Tests for PGNIG config flow with mocked API."""
+from unittest.mock import patch, MagicMock
+import pytest
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pgnig_gas_sensor.const import (
+    DOMAIN,
+    CONF_AUTH_METHOD,
+    DEFAULT_AUTH_METHOD,
+)
+from custom_components.pgnig_gas_sensor.config_flow import PGNIGGasConfigFlow
+
+
+@pytest.fixture(autouse=True)
+def auto_enable(enable_custom_integrations):
+    yield
+
+
+async def test_form_start(hass: HomeAssistant):
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert CONF_USERNAME in result["data_schema"].schema
+    assert CONF_PASSWORD in result["data_schema"].schema
+
+
+async def test_form_creates_entry_on_success(hass: HomeAssistant):
+    with patch(
+        "custom_components.pgnig_gas_sensor.config_flow.PgnigApi"
+    ) as MockApi:
+        mock_api = MagicMock()
+        MockApi.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_AUTH_METHOD: DEFAULT_AUTH_METHOD,
+                CONF_USERNAME: "test@user.pl",
+                CONF_PASSWORD: "testpass",
+            },
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["title"] == "Pgnig sensor"
+        assert result["data"][CONF_USERNAME] == "test@user.pl"
+        assert result["data"][CONF_PASSWORD] == "testpass"
+        assert result["data"][CONF_AUTH_METHOD] == DEFAULT_AUTH_METHOD
+        mock_api.login.assert_called_once()
+
+
+async def test_form_shows_error_on_failure(hass: HomeAssistant):
+    with patch(
+        "custom_components.pgnig_gas_sensor.config_flow.PgnigApi"
+    ) as MockApi:
+        mock_api = MagicMock()
+        mock_api.login.side_effect = RuntimeError("Login failed")
+        MockApi.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_AUTH_METHOD: DEFAULT_AUTH_METHOD,
+                CONF_USERNAME: "test@user.pl",
+                CONF_PASSWORD: "badpass",
+            },
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["errors"]["base"] == "verify_connection_failed"
+
+
+async def test_reauth_updates_entry(hass: HomeAssistant):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: "old@user.pl",
+            CONF_PASSWORD: "oldpass",
+            CONF_AUTH_METHOD: DEFAULT_AUTH_METHOD,
+        },
+        entry_id="test_entry_id",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.pgnig_gas_sensor.config_flow.PgnigApi"
+    ) as MockApi:
+        mock_api = MagicMock()
+        MockApi.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "entry_id": entry.entry_id,
+            },
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "reauth"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USERNAME: "new@user.pl",
+                CONF_PASSWORD: "newpass",
+            },
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["reason"] == "reauth_successful"
+        assert entry.data[CONF_USERNAME] == "new@user.pl"
+        assert entry.data[CONF_PASSWORD] == "newpass"
+
+
+async def test_reauth_shows_error_on_failure(hass: HomeAssistant):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: "old@user.pl",
+            CONF_PASSWORD: "oldpass",
+            CONF_AUTH_METHOD: DEFAULT_AUTH_METHOD,
+        },
+        entry_id="reauth_fail_id",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.pgnig_gas_sensor.config_flow.PgnigApi"
+    ) as MockApi:
+        mock_api = MagicMock()
+        mock_api.login.side_effect = RuntimeError("Still wrong")
+        MockApi.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "entry_id": entry.entry_id,
+            },
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USERNAME: "new@user.pl",
+                CONF_PASSWORD: "wrongpass",
+            },
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["errors"]["base"] == "verify_connection_failed"
+
+
+async def test_reconfigure_updates_entry(hass: HomeAssistant):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: "old@user.pl",
+            CONF_PASSWORD: "oldpass",
+            CONF_AUTH_METHOD: DEFAULT_AUTH_METHOD,
+        },
+        entry_id="reconfigure_test_id",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.pgnig_gas_sensor.config_flow.PgnigApi"
+    ) as MockApi:
+        mock_api = MagicMock()
+        MockApi.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_RECONFIGURE,
+                "entry_id": entry.entry_id,
+            },
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_AUTH_METHOD: DEFAULT_AUTH_METHOD,
+                CONF_USERNAME: "updated@user.pl",
+                CONF_PASSWORD: "updatedpass",
+            },
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        assert entry.data[CONF_USERNAME] == "updated@user.pl"
+        assert entry.data[CONF_PASSWORD] == "updatedpass"
+
+
+async def test_reconfigure_shows_error_on_failure(hass: HomeAssistant):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: "old@user.pl",
+            CONF_PASSWORD: "oldpass",
+            CONF_AUTH_METHOD: DEFAULT_AUTH_METHOD,
+        },
+        entry_id="reconfigure_fail_id",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.pgnig_gas_sensor.config_flow.PgnigApi"
+    ) as MockApi:
+        mock_api = MagicMock()
+        mock_api.login.side_effect = RuntimeError("Failed")
+        MockApi.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_RECONFIGURE,
+                "entry_id": entry.entry_id,
+            },
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_AUTH_METHOD: DEFAULT_AUTH_METHOD,
+                CONF_USERNAME: "bad@user.pl",
+                CONF_PASSWORD: "badpass",
+            },
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["errors"]["base"] == "verify_connection_failed"
+
+
+async def test_reconfigure_aborts_when_no_entry(hass: HomeAssistant):
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": "nonexistent",
+        },
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "no_config_entry"
+
+
+async def test_import_aborts(hass: HomeAssistant):
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data={CONF_USERNAME: "u", CONF_PASSWORD: "p"},
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "one_instance_at_a_time_please"

--- a/tests/test_orlen_id.py
+++ b/tests/test_orlen_id.py
@@ -1,0 +1,110 @@
+"""Tests for OrlenIDAuth auth method with mocked HTTP."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from custom_components.pgnig_gas_sensor.auth import AuthRegistry
+
+
+def _mock_resp(json_data=None, status_code=200, text=""):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.text = text
+    if json_data is not None:
+        resp.json.return_value = json_data
+    resp.headers = {}
+    return resp
+
+
+@pytest.fixture
+def auth():
+    cls = AuthRegistry.get("orlen_id")
+    return cls("oid_user@test.pl", "oid_pass")
+
+
+def test_init_sets_session_and_cookies(auth):
+    assert auth._session is not None
+    assert isinstance(auth._session, requests.Session)
+    assert auth._session.headers.get("User-Agent") is not None
+    assert auth._session.cookies.get("pgnig-ebok-device-token")
+    assert auth._cached_token == ""
+
+
+def test_session_property(auth):
+    assert auth.session is auth._session
+
+
+def test_info(auth):
+    info = auth.info
+    assert info.id == "orlen_id"
+    assert info.name == "OrlenID"
+
+
+def test_login_returns_cached_token(auth):
+    auth._cached_token = "cached-oid-token"
+    with patch.object(auth, "_init_session") as mock_init:
+        token = auth.login()
+        assert token == "cached-oid-token"
+        mock_init.assert_not_called()
+
+
+def test_login_full_flow_success(auth):
+    with patch.object(auth, "_session") as mock_session:
+        mock_session.get.return_value = _mock_resp(
+            text='<form action="https://oid.example.com/auth?execution=123&tab_id=abc">'
+        )
+        mock_session.post.return_value = _mock_resp(status_code=200)
+        mock_session.post.return_value.url = "https://ebok.myorlen.pl/home"
+        auth._device_id = "mocked-device-id"
+        mock_token_resp = _mock_resp({"Token": "oid-token-xyz"}, status_code=200)
+        mock_session.get.side_effect = [
+            _mock_resp(status_code=200),
+            _mock_resp(text='<form action="https://oid.example.com/auth">'),
+            mock_token_resp,
+        ]
+        mock_session.post.return_value = _mock_resp(status_code=200)
+        mock_session.post.return_value.url = "https://ebok.myorlen.pl/home"
+        mock_session.post.return_value.status_code = 302
+        mock_session.post.return_value.ok = True
+        token = auth.login()
+        assert token == "oid-token-xyz"
+        assert auth._cached_token == "oid-token-xyz"
+
+
+def test_login_returns_empty_when_form_not_found(auth):
+    with patch.object(auth, "_session") as mock_session:
+        mock_session.get.return_value = _mock_resp(
+            text="<html>No form here</html>"
+        )
+        mock_session.post.return_value = _mock_resp(status_code=200)
+        mock_session.post.return_value.url = "https://ebok.myorlen.pl/login"
+        assert auth.login() == ""
+
+
+def test_login_returns_empty_when_not_redirected_to_home(auth):
+    with patch.object(auth, "_session") as mock_session:
+        mock_session.get.return_value = _mock_resp(
+            text='<form action="https://oid.example.com/auth?execution=123">'
+        )
+        mock_session.post.return_value = _mock_resp(status_code=200)
+        mock_session.post.return_value.url = "https://ebok.myorlen.pl/login?error=1"
+        assert auth.login() == ""
+
+
+def test_get_auth_token_fails_returns_empty(auth):
+    with patch.object(auth, "_session") as mock_session:
+        mock_session.get.return_value = _mock_resp(
+            text='<form action="https://oid.example.com/auth">'
+        )
+        mock_session.post.return_value.url = "https://ebok.myorlen.pl/home"
+        mock_session.post.return_value.status_code = 302
+        mock_session.post.return_value.ok = True
+        mock_session.get.side_effect = [
+            _mock_resp(status_code=200),
+            _mock_resp(text="some page"),
+            _mock_resp(status_code=401),
+        ]
+        mock_session.post.return_value = _mock_resp(status_code=200)
+        assert auth.login() == ""

--- a/tests/test_pgnig_api.py
+++ b/tests/test_pgnig_api.py
@@ -1,0 +1,161 @@
+"""Tests for PgnigApi class with mocked auth and HTTP."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.pgnig_gas_sensor.PgnigApi import PgnigApi
+
+
+@pytest.fixture
+def mock_auth():
+    auth = MagicMock()
+    auth.login.return_value = "test-token"
+    auth.session = MagicMock()
+    auth.session.get.return_value.ok = True
+    auth.session.get.return_value.json.return_value = {
+        "PpgList": [{
+            "IdPPG": "123", "MeterNumber": "METER1", "ContractNumber": "C1",
+            "HasT12": True, "ReadingAdded": True, "Tariff": "T1",
+            "HasHistory": True, "Type": "G", "IdLocal": "1",
+            "ClientNumber": "100", "InstallationNumber": "INST1",
+            "Color": "red", "AgreementName": "Main",
+            "CanCreateHomeAssistant": True, "AddReadingMode": "auto",
+            "IsInMigration": False, "IsInMigrationRK": False,
+            "IsInMigrationRW": False, "IsCompany": False,
+        }],
+        "Code": 0, "Message": None, "DisplayToEndUser": False,
+        "EndUserMessage": None,
+        "TokenExpireDate": "2026-06-01T00:00:00",
+        "TokenExpireDateUtc": "2026-06-01T00:00:00",
+    }
+    return auth
+
+
+@pytest.fixture
+def api(mock_auth):
+    with patch(
+        "custom_components.pgnig_gas_sensor.PgnigApi.AuthRegistry.get",
+        return_value=MagicMock(return_value=mock_auth),
+    ):
+        return PgnigApi("user", "pass", "api_login")
+
+
+def test_init_raises_on_unknown_method():
+    with pytest.raises(ValueError, match="Unknown auth method"):
+        PgnigApi("u", "p", "nonexistent")
+
+
+def test_login_delegates_to_auth(api, mock_auth):
+    token = api.login()
+    assert token == "test-token"
+    mock_auth.login.assert_called_once()
+
+
+def test_meter_list_success(api, mock_auth):
+    ppg = api.meterList()
+    assert ppg is not None
+    assert len(ppg.ppg_list) == 1
+    assert ppg.ppg_list[0].meter_number == "METER1"
+    mock_auth.session.get.assert_called_once()
+
+
+def test_meter_list_raises_on_no_token(api, mock_auth):
+    mock_auth.login.return_value = ""
+    with pytest.raises(RuntimeError, match="Login failed - no token received"):
+        api.meterList()
+
+
+def test_meter_list_raises_on_http_error(api, mock_auth):
+    mock_auth.session.get.return_value.ok = False
+    mock_auth.session.get.return_value.status_code = 500
+    mock_auth.session.get.return_value.text = "Server Error"
+    with pytest.raises(RuntimeError, match="Meter list failed with status 500"):
+        api.meterList()
+
+
+def test_reading_for_meter_success(api, mock_auth):
+    mock_auth.session.get.return_value.json.return_value = {
+        "MeterReadings": [{
+            "Status": "OK", "ReadingDateLocal": "2026-05-01T00:00:00",
+            "ReadingDateUtc": "2026-05-01T00:00:00", "PpId": "1",
+            "Value": 123, "Value2": None, "Value3": None,
+            "MeterNumber": "METER1", "RegionCode": "PL",
+            "Wear": 50, "Type": "G", "Color": "red",
+        }],
+        "Code": 0, "Message": None, "DisplayToEndUser": False,
+        "EndUserMessage": None,
+        "TokenExpireDate": "2026-06-01T00:00:00",
+        "TokenExpireDateUtc": "2026-06-01T00:00:00",
+    }
+    readings = api.readingForMeter("123")
+    assert readings is not None
+    assert len(readings.meter_readings) == 1
+    assert readings.meter_readings[0].value == 123
+
+
+def test_reading_for_meter_raises_on_no_token(api, mock_auth):
+    mock_auth.login.return_value = ""
+    with pytest.raises(RuntimeError, match="Login failed - no token received"):
+        api.readingForMeter("123")
+
+
+def test_reading_for_meter_raises_on_http_error(api, mock_auth):
+    mock_auth.session.get.return_value.ok = False
+    mock_auth.session.get.return_value.status_code = 404
+    with pytest.raises(RuntimeError, match="Reading failed with status 404"):
+        api.readingForMeter("123")
+
+
+def test_invoices_success(api, mock_auth):
+    mock_auth.session.get.return_value.json.return_value = {
+        "InvoicesList": [{
+            "Number": "INV001", "Date": "2026-04-01T00:00:00",
+            "SellDate": "2026-04-01T00:00:00",
+            "GrossAmount": 150.0, "AmountToPay": 150.0,
+            "Wear": 0.0, "WearKWH": 100.0, "WearM3": 50.0,
+            "PayingDeadlineDate": "2026-05-01T00:00:00",
+            "StartDate": "2026-03-01T00:00:00",
+            "EndDate": "2026-03-31T00:00:00",
+            "IsPaid": False, "IdPP": "1", "Type": "G", "TempType": "G",
+            "DaysRemainingToDeadline": 10, "HasIban": True, "Iban": "PL00",
+            "Status": "OPEN", "PdfExists": True,
+            "IsInterestNote": False, "IsCreditNote": False,
+            "Color": "red", "AgreementName": "Main",
+            "AgreementNumber": "A1", "IsAdditionalAgreement": False,
+            "AgreementEndDate": None, "AgreementExpired": False,
+            "PDFPrintAllowed": True, "PaymentProcessAllowed": True,
+            "AgreementHasCard": False, "AutomaticPaymentDate": None,
+            "IsInsurancePolicy": False, "IsLawyerAgreement": False,
+        }],
+        "HasNonPaidForecast": False, "AllowLoadAfter30Days": True,
+        "AllowLoadAfter30DaysFilter": False,
+        "Code": 0, "Message": None, "DisplayToEndUser": False,
+        "EndUserMessage": None,
+        "TokenExpireDate": "2026-06-01T00:00:00",
+        "TokenExpireDateUtc": "2026-06-01T00:00:00",
+    }
+    inv = api.invoices()
+    assert inv is not None
+    assert len(inv.invoices_list) == 1
+    assert inv.invoices_list[0].number == "INV001"
+
+
+def test_invoices_raises_on_no_token(api, mock_auth):
+    mock_auth.login.return_value = ""
+    with pytest.raises(RuntimeError, match="Login failed - no token received"):
+        api.invoices()
+
+
+def test_invoices_raises_on_http_error(api, mock_auth):
+    mock_auth.session.get.return_value.ok = False
+    mock_auth.session.get.return_value.status_code = 500
+    with pytest.raises(RuntimeError, match="Invoices failed with status 500"):
+        api.invoices()
+
+
+def test_api_uses_auth_session(api, mock_auth):
+    _ = api.meterList()
+    mock_auth.session.get.assert_called_once()
+    call_args = mock_auth.session.get.call_args
+    headers = call_args[1]["headers"]
+    assert headers["AuthToken"] == "test-token"

--- a/tests/test_sensor_edge_cases.py
+++ b/tests/test_sensor_edge_cases.py
@@ -1,0 +1,269 @@
+"""Additional sensor tests covering edge cases."""
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.pgnig_gas_sensor.PpgReadingForMeter import (
+    MeterReading,
+    PpgReadingForMeter,
+)
+from custom_components.pgnig_gas_sensor.sensor import (
+    PgnigSensor,
+    PgnigInvoiceSensor,
+    PgnigCostTrackingSensor,
+)
+from custom_components.pgnig_gas_sensor.Invoices import Invoices, InvoicesList
+
+
+def _make_invoices(invoice_list):
+    return Invoices(
+        invoices_list=invoice_list,
+        code=0, message=None,
+        display_to_end_user=None,
+        token_expire_date=None,
+        allow_load_after30_days=None,
+        allow_load_after30_days_filter=False,
+        has_non_paid_forecast=None,
+        token_expire_date_utc=None,
+        end_user_message=None,
+    )
+
+
+def _make_readings(reading_list):
+    return PpgReadingForMeter(
+        meter_readings=reading_list,
+        code=0, message=None,
+        display_to_end_user=None,
+        token_expire_date=None,
+        token_expire_date_utc=None,
+        end_user_message=None,
+    )
+
+
+def _invoice(**kwargs):
+    defaults = dict(
+        number="INV", date=datetime(2022, 6, 6),
+        sell_date=datetime(2022, 6, 6),
+        gross_amount=100.0, amount_to_pay=50.0,
+        wear=10.0, wear_kwh=100.0, wear_m3=50.0,
+        paying_deadline_date=datetime(2022, 7, 6),
+        start_date=datetime(2022, 5, 1),
+        end_date=datetime(2022, 5, 31),
+        is_paid=False, id_pp="1", type="G", temp_type="G",
+        days_remaining_to_deadline=10, has_iban=True, iban="PL00",
+        status="OPEN", pdf_exists=True,
+        is_interest_note=False, is_credit_note=False,
+        color="red", agreement_name="Main",
+        agreement_number="A1", is_additional_agreement=False,
+        agreement_end_date=None, agreement_expired=False,
+        pdf_print_allowed=True, payment_process_allowed=True,
+        agreement_has_card=False, automatic_payment_date=None,
+        is_insurance_policy=False, is_lawyer_agreement=False,
+    )
+    defaults.update(kwargs)
+    return InvoicesList(**defaults)
+
+
+def _reading(**kwargs):
+    defaults = dict(
+        status="OK", reading_date_local=datetime(2022, 6, 6),
+        reading_date_utc=datetime(2022, 6, 6),
+        pp_id=1, value=100, value2=None, value3=None,
+        meter_number="M1", region_code="PL", wear=50,
+        type="G", color="red",
+    )
+    defaults.update(kwargs)
+    return MeterReading(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_sensor_no_readings_returns_none(hass: HomeAssistant):
+    api = MagicMock()
+    api.readingForMeter.return_value = _make_readings([])
+    sensor = PgnigSensor(hass, api, "M1", 1)
+    await sensor.async_update()
+    assert sensor.state is None
+
+
+@pytest.mark.asyncio
+async def test_sensor_native_unit_and_device_class(hass: HomeAssistant):
+    api = MagicMock()
+    sensor = PgnigSensor(hass, api, "M1", 1)
+    assert sensor.native_unit_of_measurement == "m³"
+    assert sensor.device_class == "gas"
+    assert sensor.state_class == "total_increasing"
+
+
+@pytest.mark.asyncio
+async def test_sensor_unique_id_format(hass: HomeAssistant):
+    api = MagicMock()
+    sensor = PgnigSensor(hass, api, "METER-X", 42)
+    assert sensor.unique_id == "pgnig_sensorMETER-X_42"
+
+
+@pytest.mark.asyncio
+async def test_sensor_name(hass: HomeAssistant):
+    api = MagicMock()
+    sensor = PgnigSensor(hass, api, "M1", 1)
+    assert "Orlen Gas Sensor" in sensor.name
+    assert "M1" in sensor.name
+
+
+@pytest.mark.asyncio
+async def test_sensor_extra_state_attributes(hass: HomeAssistant):
+    api = MagicMock()
+    api.readingForMeter.return_value = _make_readings([
+        _reading(wear=75),
+    ])
+    sensor = PgnigSensor(hass, api, "M1", 1)
+    await sensor.async_update()
+    attrs = sensor.extra_state_attributes
+    assert attrs["wear"] == 75
+
+
+@pytest.mark.asyncio
+async def test_sensor_state_none_when_not_updated():
+    api = MagicMock()
+    sensor = PgnigSensor(MagicMock(), api, "M1", 1)
+    assert sensor.state is None
+
+
+@pytest.mark.asyncio
+async def test_invoice_sensor_no_invoices(hass: HomeAssistant):
+    api = MagicMock()
+    api.invoices.return_value = _make_invoices([])
+    sensor = PgnigInvoiceSensor(hass, api, "M1", 1)
+    await sensor.async_update()
+    assert sensor.state == 0
+
+
+@pytest.mark.asyncio
+async def test_invoice_sensor_attributes(hass: HomeAssistant):
+    api = MagicMock()
+    api.invoices.return_value = _make_invoices([
+        _invoice(id_pp="1", is_paid=False, amount_to_pay=75.0,
+                 paying_deadline_date=datetime(2022, 8, 15)),
+    ])
+    sensor = PgnigInvoiceSensor(hass, api, "M1", 1)
+    await sensor.async_update()
+    attrs = sensor.extra_state_attributes
+    assert attrs["next_payment_amount_to_pay"] == 75.0
+    assert attrs["next_payment_date"] == datetime(2022, 8, 15)
+
+
+@pytest.mark.asyncio
+async def test_invoice_sensor_unique_id(hass: HomeAssistant):
+    api = MagicMock()
+    sensor = PgnigInvoiceSensor(hass, api, "M2", 3)
+    assert sensor.unique_id == "pgnig_invoice_sensorM2_3"
+
+
+@pytest.mark.asyncio
+async def test_invoice_sensor_native_unit(hass: HomeAssistant):
+    api = MagicMock()
+    sensor = PgnigInvoiceSensor(hass, api, "M1", 1)
+    assert sensor.native_unit_of_measurement == "PLN"
+    assert sensor.device_class == "monetary"
+
+
+@pytest.mark.asyncio
+async def test_cost_sensor_only_matching_meters(hass: HomeAssistant):
+    api = MagicMock()
+    api.invoices.return_value = _make_invoices([
+        _invoice(id_pp="999", gross_amount=50.0, wear_m3=10.0),
+    ])
+    sensor = PgnigCostTrackingSensor(hass, api, "M1", 1)
+    await sensor.async_update()
+    assert sensor.state is None
+
+
+@pytest.mark.asyncio
+async def test_cost_sensor_credit_note_skipped(hass: HomeAssistant):
+    api = MagicMock()
+    api.invoices.return_value = _make_invoices([
+        _invoice(id_pp="1", is_credit_note=True, gross_amount=50.0, wear_m3=10.0),
+    ])
+    sensor = PgnigCostTrackingSensor(hass, api, "M1", 1)
+    await sensor.async_update()
+    assert sensor.state is None
+
+
+@pytest.mark.asyncio
+async def test_cost_sensor_state_none_when_not_updated():
+    api = MagicMock()
+    sensor = PgnigCostTrackingSensor(MagicMock(), api, "M1", 1)
+    assert sensor.state is None
+
+
+@pytest.mark.asyncio
+async def test_invoice_sensor_state_none_when_not_updated():
+    api = MagicMock()
+    sensor = PgnigInvoiceSensor(MagicMock(), api, "M1", 1)
+    assert sensor.state is None
+
+
+@pytest.mark.asyncio
+async def test_sensor_device_info(hass: HomeAssistant):
+    api = MagicMock()
+    sensor = PgnigSensor(hass, api, "M-123", 5)
+    info = sensor.device_info
+    assert info["identifiers"] == {("pgnig_gas_sensor", "M-123")}
+    assert "Orlen" in info["name"]
+
+
+@pytest.mark.asyncio
+async def test_invoice_sensor_device_info(hass: HomeAssistant):
+    api = MagicMock()
+    sensor = PgnigInvoiceSensor(hass, api, "M-123", 5)
+    info = sensor.device_info
+    assert info["identifiers"] == {("pgnig_gas_sensor", "M-123")}
+
+
+@pytest.mark.asyncio
+async def test_cost_sensor_device_info(hass: HomeAssistant):
+    api = MagicMock()
+    sensor = PgnigCostTrackingSensor(hass, api, "M-123", 5)
+    info = sensor.device_info
+    assert info["identifiers"] == {("pgnig_gas_sensor", "M-123")}
+
+
+@pytest.mark.asyncio
+async def test_invoice_sensor_attributes_none_when_no_invoice(hass: HomeAssistant):
+    api = MagicMock()
+    api.invoices.return_value = _make_invoices([])
+    sensor = PgnigInvoiceSensor(hass, api, "M1", 1)
+    await sensor.async_update()
+    attrs = sensor.extra_state_attributes
+    assert attrs["next_payment_date"] is None
+    assert attrs["next_payment_amount_to_pay"] is None
+    assert attrs["next_payment_wear"] is None
+    assert attrs["next_payment_wear_KWH"] is None
+
+
+@pytest.mark.asyncio
+async def test_cost_sensor_extra_state_attributes(hass: HomeAssistant):
+    api = MagicMock()
+    invoice = _invoice(
+        id_pp="1", gross_amount=200.0, wear_m3=50.0,
+        paying_deadline_date=datetime(2022, 9, 1),
+        number="INV-123",
+    )
+    api.invoices.return_value = _make_invoices([invoice])
+    sensor = PgnigCostTrackingSensor(hass, api, "M1", 1)
+    await sensor.async_update()
+    attrs = sensor.extra_state_attributes
+    assert attrs["last_invoice_date"] == datetime(2022, 9, 1)
+    assert attrs["last_invoice_gross_amount"] == 200.0
+    assert attrs["last_invoice_wear_m3"] == 50.0
+    assert attrs["last_invoice_number"] == "INV-123"
+
+
+@pytest.mark.asyncio
+async def test_cost_sensor_attributes_none_when_no_data(hass: HomeAssistant):
+    api = MagicMock()
+    api.invoices.return_value = _make_invoices([])
+    sensor = PgnigCostTrackingSensor(hass, api, "M1", 1)
+    await sensor.async_update()
+    assert sensor.extra_state_attributes == {}


### PR DESCRIPTION
## Summary

- Added  to  and 

## Problem

Since v3.0, the invoice and cost tracking sensors lost their state class, causing HA to display:

> We have generated statistics for '...' in the past, but it no longer has a state class, therefore, we cannot track long term statistics for it anymore.

## Fix

Both sensors now properly set  since their values represent point-in-time measurements:
- **Invoice sensor**: sum of unpaid invoices (changes as invoices are created/paid)
- **Cost tracking sensor**: cost per m³ (changes per billing period)

## Testing

All 75 existing tests pass.