### PR TITLE
fix: add missing state_class to invoice and cost tracking sensors

### DIFF
--- a/custom_components/pgnig_gas_sensor/sensor.py
+++ b/custom_components/pgnig_gas_sensor/sensor.py
@@ -132,6 +132,7 @@ class PgnigInvoiceSensor(SensorEntity):
     def __init__(self, hass, api: PgnigApi, meter_id: string, id_local: int) -> None:
         self._attr_native_unit_of_measurement = "PLN"
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._state: MeterReading | None = None
         self.hass = hass
         self.api = api
@@ -204,6 +205,7 @@ class PgnigCostTrackingSensor(SensorEntity):
     def __init__(self, hass, api: PgnigApi, meter_id: string, id_local: int) -> None:
         self._attr_native_unit_of_measurement = "PLN/m³"
         self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._state: InvoicesList | None = None
         self.hass = hass
         self.api = api


### PR DESCRIPTION
## Summary

- Added `_attr_state_class = SensorStateClass.MEASUREMENT` to `PgnigInvoiceSensor` and `PgnigCostTrackingSensor`

## Problem

Since v3.0, the invoice and cost tracking sensors lost their state class, causing HA to display:

> We have generated statistics for '...' in the past, but it no longer has a state class, therefore, we cannot track long term statistics for it anymore.

## Fix

Both sensors now properly set `SensorStateClass.MEASUREMENT` since their values represent point-in-time measurements:
- **Invoice sensor**: sum of unpaid invoices (changes as invoices are created/paid)
- **Cost tracking sensor**: cost per m³ (changes per billing period)

## Testing

All 75 existing tests pass.