### PR TITLE
feat: add OrlenID SMS MFA support

### DIFF
--- a/custom_components/pgnig_gas_sensor/PgnigApi.py
+++ b/custom_components/pgnig_gas_sensor/PgnigApi.py
@@ -1,33 +1,49 @@
 import logging
 
 from .Invoices import invoices_from_dict, Invoices
-from .PgpList import (PpgList, ppg_list_from_dict)
+from .PgpList import PpgList, ppg_list_from_dict
 from .PpgReadingForMeter import PpgReadingForMeter, ppg_reading_for_meter_from_dict
 from .auth import AuthRegistry
-from .const import DEFAULT_AUTH_METHOD
+from .auth.orlen_id import OrlenIDAuth
+from .const import AUTH_METHOD_ORLEN_ID, DEFAULT_AUTH_METHOD
 
 _LOGGER = logging.getLogger(__name__)
 
 devices_list_url = "https://ebok.myorlen.pl/crm/get-ppg-list?api-version=3.0"
-readings_url = "https://ebok.myorlen.pl/crm/get-all-ppg-readings-for-meter?pageSize=10&pageNumber=1&api-version=3.0&idPpg="
-invoices_url = "https://ebok.myorlen.pl/crm/get-invoices-v2?pageNumber=1&pageSize=12&api-version=3.0"
+readings_url = (
+    "https://ebok.myorlen.pl/crm/get-all-ppg-readings-for-meter"
+    "?pageSize=10&pageNumber=1&api-version=3.0&idPpg="
+)
+invoices_url = (
+    "https://ebok.myorlen.pl/crm/get-invoices-v2"
+    "?pageNumber=1&pageSize=12&api-version=3.0"
+)
 
 
 class PgnigApi:
-
-    def __init__(self, username, password, auth_method=DEFAULT_AUTH_METHOD) -> None:
+    def __init__(
+        self,
+        username,
+        password,
+        auth_method=DEFAULT_AUTH_METHOD,
+        session_data=None,
+    ) -> None:
         self.username = username
         self.password = password
         auth_class = AuthRegistry.get(auth_method)
         if auth_class is None:
             raise ValueError(f"Unknown auth method: {auth_method}")
-        self._auth = auth_class(username, password)
+        self._auth_method = auth_method
+        if auth_method == AUTH_METHOD_ORLEN_ID:
+            self._auth = auth_class(username, password, session_data=session_data)
+        else:
+            self._auth = auth_class(username, password)
 
     def _api_headers(self, token):
         return {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            'AuthToken': token,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "AuthToken": token,
         }
 
     def meterList(self) -> PpgList:
@@ -36,16 +52,22 @@ class PgnigApi:
             raise RuntimeError("Login failed - no token received")
         resp = self._auth.session.get(devices_list_url, headers=self._api_headers(token))
         if not resp.ok:
-            raise RuntimeError(f"Meter list failed with status {resp.status_code}: {resp.text[:200]}")
+            raise RuntimeError(
+                f"Meter list failed with status {resp.status_code}: {resp.text[:200]}"
+            )
         return ppg_list_from_dict(resp.json())
 
     def readingForMeter(self, meter_id) -> PpgReadingForMeter:
         token = self.login()
         if not token:
             raise RuntimeError("Login failed - no token received")
-        resp = self._auth.session.get(readings_url + meter_id, headers=self._api_headers(token))
+        resp = self._auth.session.get(
+            readings_url + meter_id, headers=self._api_headers(token)
+        )
         if not resp.ok:
-            raise RuntimeError(f"Reading failed with status {resp.status_code}: {resp.text[:200]}")
+            raise RuntimeError(
+                f"Reading failed with status {resp.status_code}: {resp.text[:200]}"
+            )
         return ppg_reading_for_meter_from_dict(resp.json())
 
     def invoices(self) -> Invoices:
@@ -54,9 +76,25 @@ class PgnigApi:
             raise RuntimeError("Login failed - no token received")
         resp = self._auth.session.get(invoices_url, headers=self._api_headers(token))
         if not resp.ok:
-            raise RuntimeError(f"Invoices failed with status {resp.status_code}: {resp.text[:200]}")
+            raise RuntimeError(
+                f"Invoices failed with status {resp.status_code}: {resp.text[:200]}"
+            )
         return invoices_from_dict(resp.json())
 
     def login(self) -> str:
         _LOGGER.debug("PgnigApi.login() delegating to %s", type(self._auth).__name__)
         return self._auth.login()
+
+    def export_orlen_session(self) -> dict | None:
+        if self._auth_method != AUTH_METHOD_ORLEN_ID or not isinstance(
+            self._auth, OrlenIDAuth
+        ):
+            return None
+        return self._auth.export_session()
+
+    def complete_mfa(self, pending: dict, code: str) -> str:
+        if self._auth_method != AUTH_METHOD_ORLEN_ID:
+            raise ValueError("MFA is only supported for OrlenID authentication")
+        if not isinstance(self._auth, OrlenIDAuth):
+            raise ValueError("OrlenID auth handler is not active")
+        return self._auth.complete_mfa(pending, code)

--- a/custom_components/pgnig_gas_sensor/__init__.py
+++ b/custom_components/pgnig_gas_sensor/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers import entity_registry
 
-from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
+from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD, CONF_ORLEN_SESSION
 from .PgnigApi import PgnigApi
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,7 +37,8 @@ async def async_setup_entry(hass, config_entry):
     user = config_entry.data[CONF_USERNAME]
     password = config_entry.data[CONF_PASSWORD]
     auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
-    api = PgnigApi(user, password, auth_method)
+    session_data = config_entry.data.get(CONF_ORLEN_SESSION)
+    api = PgnigApi(user, password, auth_method, session_data=session_data)
     hass.data[DOMAIN][config_entry.entry_id] = api
 
     await hass.config_entries.async_forward_entry_setups(config_entry, ["sensor", "button"])
@@ -70,9 +71,13 @@ async def async_setup_entry(hass, config_entry):
 
 
 async def async_unload_entry(hass, config_entry):
-    if hass.services.async_has_service(DOMAIN, "refresh"):
+    if hass.services.has_service(DOMAIN, "refresh"):
         hass.services.async_remove(DOMAIN, "refresh")
     hass.data[DOMAIN].pop(config_entry.entry_id, None)
-    await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
-    await hass.config_entries.async_forward_entry_unload(config_entry, "button")
-    return True
+    unload_ok = True
+    for platform in ("sensor", "button"):
+        if not await hass.config_entries.async_forward_entry_unload(
+            config_entry, platform
+        ):
+            unload_ok = False
+    return unload_ok

--- a/custom_components/pgnig_gas_sensor/auth/__init__.py
+++ b/custom_components/pgnig_gas_sensor/auth/__init__.py
@@ -59,4 +59,5 @@ def device_id(username: str) -> str:
 
 
 from .api_login import ApiLoginAuth  # noqa: E402
+from .exceptions import AuthError, InvalidAuthError, MfaFailedError, MfaRequired  # noqa: E402
 from .orlen_id import OrlenIDAuth  # noqa: E402

--- a/custom_components/pgnig_gas_sensor/auth/exceptions.py
+++ b/custom_components/pgnig_gas_sensor/auth/exceptions.py
@@ -1,0 +1,25 @@
+"""Authentication exceptions for Orlen EBOK login flows."""
+
+
+class AuthError(Exception):
+    """Base class for authentication errors."""
+
+
+class InvalidAuthError(AuthError):
+    """Username or password was rejected."""
+
+
+class MfaRequired(AuthError):
+    """OrlenID login requires an MFA code; session state is preserved for the next step."""
+
+    def __init__(self, pending: dict) -> None:
+        super().__init__("MFA code required")
+        self.pending = pending
+
+
+class MfaFailedError(AuthError):
+    """Submitted MFA code was rejected."""
+
+
+class MfaSessionExpiredError(MfaFailedError):
+    """MFA session expired; user must log in again with password."""

--- a/custom_components/pgnig_gas_sensor/auth/orlen_id.py
+++ b/custom_components/pgnig_gas_sensor/auth/orlen_id.py
@@ -1,42 +1,224 @@
 """OrlenID OID login strategy for Orlen EBOK."""
+from __future__ import annotations
+
 import logging
 import re
+from html import unescape
+from typing import Any
+from urllib.parse import urljoin
 
 import requests
+from requests.cookies import cookiejar_from_dict
 
 from . import AuthMethod, AuthMethodInfo, AuthRegistry, device_id
+from .exceptions import (
+    InvalidAuthError,
+    MfaFailedError,
+    MfaRequired,
+    MfaSessionExpiredError,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 BASE_URL = "https://ebok.myorlen.pl"
 
 browser_headers = {
-    'Accept-Language': 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
-    'Cache-Control': 'no-cache',
-    'Content-Type': 'application/json',
-    'Origin': BASE_URL,
-    'Pragma': 'no-cache',
-    'Referer': f'{BASE_URL}/',
-    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
-    'sec-ch-ua': '"Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"',
-    'sec-ch-ua-mobile': '?0',
-    'sec-ch-ua-platform': '"macOS"',
-    'Sec-Fetch-Dest': 'empty',
-    'Sec-Fetch-Mode': 'cors',
-    'Sec-Fetch-Site': 'same-origin',
+    "Accept-Language": "pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Cache-Control": "no-cache",
+    "Content-Type": "application/json",
+    "Origin": BASE_URL,
+    "Pragma": "no-cache",
+    "Referer": f"{BASE_URL}/",
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+    ),
+    "sec-ch-ua": '"Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"macOS"',
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-origin",
 }
+
+FORM_URLENCODED_HEADERS = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+}
+
+# netzbegruenung SMS authenticator uses name="code"; login-otp.ftl uses "otp"/"totp".
+MFA_FIELD_CANDIDATES = ("code", "otp", "totp", "smsCode", "mfa_code", "verificationCode")
+
+LOGIN_FORM_FIELD_NAMES = {"username", "password", "credentialId"}
+
+
+def _iter_forms(html: str, base_url: str) -> list[tuple[str, dict[str, str]]]:
+    forms: list[tuple[str, dict[str, str]]] = []
+    for form_match in re.finditer(
+        r"<form\b[^>]*action=\"([^\"]+)\"[^>]*>(.*?)</form>",
+        html,
+        re.IGNORECASE | re.DOTALL,
+    ):
+        action = unescape(form_match.group(1).replace("&amp;", "&"))
+        if action.startswith("/"):
+            action = urljoin(base_url, action)
+        fields: dict[str, str] = {}
+        for input_match in re.finditer(
+            r"<input[^>]+name=\"([^\"]+)\"[^>]*>",
+            form_match.group(2),
+            re.IGNORECASE,
+        ):
+            tag = input_match.group(0)
+            name = input_match.group(1)
+            value_match = re.search(r'value="([^"]*)"', tag, re.IGNORECASE)
+            input_type = re.search(r'type="([^"]+)"', tag, re.IGNORECASE)
+            if input_type and input_type.group(1).lower() in {"submit", "button", "image"}:
+                if name:
+                    fields[name] = value_match.group(1) if value_match else ""
+                continue
+            fields[name] = unescape(value_match.group(1) if value_match else "")
+        forms.append((action, fields))
+    return forms
+
+
+def _extract_form(html: str, base_url: str) -> tuple[str, dict[str, str]]:
+    forms = _iter_forms(html, base_url)
+    return forms[0] if forms else ("", {})
+
+
+def _find_mfa_form(html: str, base_url: str) -> tuple[str, dict[str, str], str]:
+    """Return MFA form action, hidden fields, and OTP field name."""
+    for action, fields in _iter_forms(html, base_url):
+        field_name = _detect_mfa_field(html, fields)
+        if not field_name:
+            continue
+        mfa_fields = {
+            k: v
+            for k, v in fields.items()
+            if k not in LOGIN_FORM_FIELD_NAMES and k != field_name
+        }
+        return action, mfa_fields, field_name
+    return "", {}, ""
+
+
+def _detect_mfa_field(html: str, fields: dict[str, str]) -> str | None:
+    lowered = html.lower()
+    if not any(
+        token in lowered
+        for token in ("otp", "totp", "sms", "kod", "weryfik", "uwierzyteln", "mfa", "jednoraz")
+    ):
+        return None
+
+    for candidate in MFA_FIELD_CANDIDATES:
+        if candidate in fields:
+            return candidate
+        if re.search(rf'name=["\']{candidate}["\']', html, re.IGNORECASE):
+            return candidate
+    return None
+
+
+def _is_keycloak_url(url: str) -> bool:
+    lowered = url.lower()
+    return any(
+        token in lowered
+        for token in ("login-actions", "openid-connect", "orlenid", "keycloak", "/auth/realms/")
+    )
+
+
+def _looks_like_mfa_challenge(response: requests.Response) -> bool:
+    if f"{BASE_URL}/home" in response.url:
+        return False
+    _, _, field_name = _find_mfa_form(response.text, response.url)
+    return bool(field_name)
+
+
+def _normalize_otp_code(code: str) -> str:
+    return re.sub(r"\D", "", (code or "").strip())
+
+
+def _cookies_for_storage(jar: requests.cookies.RequestsCookieJar) -> list[dict[str, str]]:
+    """Serialize session cookies with domain/path for MFA step restore."""
+    cookies: list[dict[str, str]] = []
+    internal = getattr(jar, "_cookies", None)
+    if internal:
+        for domain, paths in internal.items():
+            for path, names in paths.items():
+                for cookie in names.values():
+                    cookies.append(
+                        {
+                            "name": cookie.name,
+                            "value": cookie.value,
+                            "domain": cookie.domain or domain or "",
+                            "path": cookie.path or path or "/",
+                        }
+                    )
+        return cookies
+
+    for name, value in jar.get_dict().items():
+        cookies.append(
+            {"name": name, "value": value, "domain": "", "path": "/"}
+        )
+    return cookies
+
+
+def _restore_cookies(session: requests.Session, cookies: list[dict[str, str]]) -> None:
+    session.cookies.clear()
+    for cookie in cookies:
+        set_kwargs: dict[str, str] = {"path": cookie.get("path") or "/"}
+        domain = (cookie.get("domain") or "").strip()
+        if domain:
+            set_kwargs["domain"] = domain
+        session.cookies.set(
+            cookie["name"],
+            cookie["value"],
+            **set_kwargs,
+        )
+
+
+def _is_login_page(html: str) -> bool:
+    for _, fields in _iter_forms(html, ""):
+        if "username" in fields and "password" in fields:
+            return _detect_mfa_field(html, fields) is None
+    return False
+
+
+def _build_mfa_payload(
+    form_fields: dict[str, str],
+    field_name: str,
+    otp_code: str,
+) -> dict[str, str]:
+    """Build POST body for MFA form without polluting SMS forms with login fields."""
+    payload = dict(form_fields)
+    payload[field_name] = otp_code
+    # Standard Keycloak OTP/TOTP forms use a submit input named "login".
+    if field_name in {"otp", "totp"} and "login" not in payload:
+        payload["login"] = "Log In"
+    return payload
 
 
 @AuthRegistry.register
 class OrlenIDAuth(AuthMethod):
-    def __init__(self, username, password) -> None:
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        session_data: dict[str, Any] | None = None,
+    ) -> None:
         self.username = username
         self.password = password
         self._device_id = device_id(username)
         self._session = requests.Session()
         self._session.headers.update(browser_headers)
-        self._session.cookies.set("pgnig-ebok-device-token", self._device_id)
         self._cached_token: str = ""
+        if session_data:
+            self._device_id = session_data.get("device_id", self._device_id)
+            cookies = session_data.get("cookies", [])
+            if isinstance(cookies, dict):
+                cookiejar_from_dict(cookies, self._session.cookies)
+            elif cookies:
+                _restore_cookies(self._session, cookies)
+            self._cached_token = session_data.get("token", "")
+        self._session.cookies.set("pgnig-ebok-device-token", self._device_id)
 
     @property
     def session(self) -> requests.Session:
@@ -47,71 +229,281 @@ class OrlenIDAuth(AuthMethod):
         return AuthMethodInfo(
             id="orlen_id",
             name="OrlenID",
-            description="OrlenID OID login"
+            description="OrlenID OID login",
         )
 
-    def _init_session(self):
+    def _init_session(self) -> None:
         _LOGGER.debug("Initializing session with GET %s", BASE_URL)
         resp = self._session.get(BASE_URL, timeout=30)
-        _LOGGER.debug("Session init status: %s, cookies: %s", resp.status_code, dict(self._session.cookies))
+        _LOGGER.debug(
+            "Session init status: %s, cookies: %s",
+            resp.status_code,
+            dict(self._session.cookies),
+        )
+
+    def _fetch_auth_token(self) -> str:
+        auth_token_url = (
+            f"{BASE_URL}/auth/get-auth-token?deviceId={self._device_id}&api-version=3.0"
+        )
+        res_auth = self._session.get(
+            auth_token_url,
+            headers={
+                "Accept": "application/json, text/plain, */*",
+                "Referer": f"{BASE_URL}/home",
+            },
+            timeout=30,
+        )
+        _LOGGER.debug("Auth token response: status=%s", res_auth.status_code)
+        if res_auth.status_code != 200:
+            raise RuntimeError(
+                f"Auth token request failed with status {res_auth.status_code}: "
+                f"{res_auth.text[:200]}"
+            )
+        token = res_auth.json().get("Token", "")
+        if not token:
+            raise RuntimeError("Auth token response missing Token field")
+        self._cached_token = token
+        return token
+
+    def _complete_oidc_session(self, response: requests.Response) -> str:
+        """Finish OIDC login after password or MFA and fetch EBOK API token."""
+        if _looks_like_mfa_challenge(response):
+            raise MfaFailedError("Invalid or expired MFA code")
+
+        if _is_keycloak_url(response.url):
+            if _is_login_page(response.text):
+                raise MfaSessionExpiredError(
+                    "MFA session expired — log in again with username and password, "
+                    "then enter the latest SMS code."
+                )
+            raise MfaFailedError(
+                "Authentication did not complete; still on OrlenID login page"
+            )
+
+        if f"{BASE_URL}/home" not in response.url:
+            _LOGGER.info(
+                "OrlenID post-auth URL is %s; navigating to /home before token fetch",
+                response.url,
+            )
+            response = self._session.get(
+                f"{BASE_URL}/home",
+                headers={"Referer": response.url},
+                timeout=30,
+                allow_redirects=True,
+            )
+
+        if _looks_like_mfa_challenge(response):
+            raise MfaFailedError("Invalid or expired MFA code")
+
+        if _is_keycloak_url(response.url):
+            raise MfaFailedError(
+                "Authentication did not complete; OrlenID redirected back to login"
+            )
+
+        return self._fetch_auth_token()
+
+    def _build_pending_mfa(self, response: requests.Response) -> dict[str, Any]:
+        action, fields, mfa_field = _find_mfa_form(response.text, response.url)
+        if not action or not mfa_field:
+            raise InvalidAuthError(
+                "OrlenID rejected credentials or returned an unexpected login page"
+            )
+        _LOGGER.info(
+            "OrlenID MFA required; post_url=%s field=%s hidden_fields=%s",
+            action,
+            mfa_field,
+            list(fields.keys()),
+        )
+        return {
+            "username": self.username,
+            "password": self.password,
+            "device_id": self._device_id,
+            "cookies": _cookies_for_storage(self._session.cookies),
+            "mfa_post_url": action,
+            "mfa_form_fields": fields,
+            "mfa_field_name": mfa_field,
+            "mfa_referer": response.url,
+        }
+
+    @classmethod
+    def from_pending(cls, pending: dict[str, Any]) -> OrlenIDAuth:
+        auth = cls.__new__(cls)
+        auth.username = pending["username"]
+        auth.password = pending.get("password", "")
+        auth._device_id = pending["device_id"]
+        auth._cached_token = ""
+        auth._session = requests.Session()
+        auth._session.headers.update(browser_headers)
+        cookies = pending.get("cookies", [])
+        if isinstance(cookies, dict):
+            auth._session.cookies = cookiejar_from_dict(cookies)
+        else:
+            _restore_cookies(auth._session, cookies)
+        auth._session.cookies.set("pgnig-ebok-device-token", auth._device_id)
+        return auth
+
+    def complete_mfa(self, pending: dict[str, Any], code: str) -> str:
+        """Submit SMS / OTP code and finish OrlenID login."""
+        auth = self.from_pending(pending)
+        post_url = pending["mfa_post_url"]
+        field_name = pending["mfa_field_name"]
+        otp_code = _normalize_otp_code(code)
+        if not otp_code:
+            raise MfaFailedError("MFA code is empty")
+
+        payload = _build_mfa_payload(
+            pending.get("mfa_form_fields", {}),
+            field_name,
+            otp_code,
+        )
+
+        _LOGGER.info(
+            "Submitting OrlenID MFA to %s using field %s payload_keys=%s",
+            post_url,
+            field_name,
+            sorted(payload.keys()),
+        )
+        response = auth._session.post(
+            post_url,
+            data=payload,
+            headers={
+                **FORM_URLENCODED_HEADERS,
+                "Referer": pending.get("mfa_referer", post_url),
+                "Origin": urljoin(post_url, "/"),
+            },
+            timeout=30,
+            allow_redirects=True,
+        )
+        _LOGGER.info(
+            "OrlenID MFA response: final_url=%s status=%s",
+            response.url,
+            response.status_code,
+        )
+
+        if _looks_like_mfa_challenge(response):
+            refreshed = auth._build_pending_mfa(response)
+            pending.update(refreshed)
+            raise MfaFailedError(
+                "Invalid MFA code — enter the latest SMS code without spaces."
+            )
+
+        try:
+            token = auth._complete_oidc_session(response)
+        except MfaSessionExpiredError:
+            _LOGGER.warning(
+                "OrlenID MFA session expired; user must restart login with password"
+            )
+            raise
+        except MfaFailedError:
+            _LOGGER.warning(
+                "OrlenID MFA failed; response snippet: %s",
+                response.text[:300].replace("\n", " "),
+            )
+            raise
+
+        self._session = auth._session
+        self._cached_token = token
+        self._device_id = auth._device_id
+        return token
+
+    def export_session(self) -> dict[str, Any]:
+        return {
+            "device_id": self._device_id,
+            "cookies": _cookies_for_storage(self._session.cookies),
+            "token": self._cached_token,
+        }
+
+    def _try_restore_session_token(self) -> str | None:
+        if not self._cached_token and not list(self._session.cookies.keys()):
+            return None
+        try:
+            return self._fetch_auth_token()
+        except RuntimeError:
+            _LOGGER.debug("Stored OrlenID session is no longer valid")
+            self._cached_token = ""
+            return None
 
     def login(self) -> str:
         if self._cached_token:
             _LOGGER.debug("Using cached auth token")
             return self._cached_token
 
+        restored = self._try_restore_session_token()
+        if restored:
+            return restored
+
         _LOGGER.debug("Starting OrlenID login flow for user %s", self.username)
         self._init_session()
 
-        init_url = f'{BASE_URL}/auth/oid/init-login?api-version=3.0'
+        init_url = f"{BASE_URL}/auth/oid/init-login?api-version=3.0"
         init_data = {
             "DeviceId": self._device_id,
             "DeviceType": "Web",
             "DeviceName": "HomeAssistant wersja: 0.1",
             "LightweightRedirectUrl": f"{BASE_URL}/?show=modal",
-            "FinalizeRegistrationRedirectUrl": f"{BASE_URL}/aktywuj-oid/"
+            "FinalizeRegistrationRedirectUrl": f"{BASE_URL}/aktywuj-oid/",
         }
 
         response_init = self._session.post(init_url, json=init_data, timeout=30)
-        _LOGGER.debug("Init login response: status=%s, body=%s", response_init.status_code, response_init.text[:300])
-        redirect_url = response_init.json().get('RedirectUrl')
-        _LOGGER.debug("Redirect URL received: %s", redirect_url)
+        _LOGGER.debug(
+            "Init login response: status=%s, body=%s",
+            response_init.status_code,
+            response_init.text[:300],
+        )
+        if not response_init.ok:
+            raise RuntimeError(
+                f"OrlenID init-login failed with status {response_init.status_code}"
+            )
+
+        redirect_url = response_init.json().get("RedirectUrl")
+        if not redirect_url:
+            raise RuntimeError("OrlenID init-login response missing RedirectUrl")
 
         response_page = self._session.get(redirect_url, timeout=30)
         match = re.search(r'action="([^"]+)"', response_page.text)
-        _LOGGER.debug("Login page fetched: status=%s, form action found=%s", response_page.status_code, match is not None)
+        _LOGGER.debug(
+            "Login page fetched: status=%s, form action found=%s",
+            response_page.status_code,
+            match is not None,
+        )
+        if not match:
+            raise RuntimeError("OrlenID login form not found on SSO page")
 
-        if match:
-            post_url = match.group(1).replace('&amp;', '&')
-            _LOGGER.debug("Posting credentials to %s", post_url)
-            payload = {
-                'username': self.username,
-                'password': self.password,
-                'credentialId': ''
-            }
-            final_response = self._session.post(post_url, data=payload, headers={
-                'Referer': redirect_url,
-                'Content-Type': 'application/x-www-form-urlencoded',
-            }, timeout=30)
-            _LOGGER.debug("Credentials posted: final_url=%s, status=%s", final_response.url, final_response.status_code)
+        post_url = match.group(1).replace("&amp;", "&")
+        _LOGGER.debug("Posting credentials to %s", post_url)
+        final_response = self._session.post(
+            post_url,
+            data={
+                "username": self.username,
+                "password": self.password,
+                "credentialId": "",
+            },
+            headers={
+                **FORM_URLENCODED_HEADERS,
+                "Referer": redirect_url,
+                "Origin": urljoin(post_url, "/"),
+            },
+            timeout=30,
+            allow_redirects=True,
+        )
+        _LOGGER.debug(
+            "Credentials posted: final_url=%s, status=%s",
+            final_response.url,
+            final_response.status_code,
+        )
 
-            if f"{BASE_URL}/home" in final_response.url:
-                _LOGGER.debug("Login successful, fetching auth token")
-                auth_token_url = f'{BASE_URL}/auth/get-auth-token?deviceId={self._device_id}&api-version=3.0'
-                res_auth = self._session.get(auth_token_url, headers={
-                    'Accept': 'application/json, text/plain, */*',
-                    'Referer': f'{BASE_URL}/home',
-                }, timeout=30)
-                _LOGGER.debug("Auth token response: status=%s", res_auth.status_code)
-                if res_auth.status_code == 200:
-                    self._cached_token = res_auth.json().get('Token', "")
-                    token_preview = self._cached_token[:20] + "..." if self._cached_token else "empty"
-                    _LOGGER.debug("Token obtained: %s", token_preview)
-                    return self._cached_token
-                else:
-                    _LOGGER.debug("Auth token request failed: status=%s, body=%s", res_auth.status_code, res_auth.text[:200])
-            else:
-                _LOGGER.debug("Login failed: redirect ended at %s instead of %s/home", final_response.url, BASE_URL)
-        else:
-            _LOGGER.debug("Login form not found in page at %s", redirect_url)
-        return ""
+        if _looks_like_mfa_challenge(final_response):
+            raise MfaRequired(self._build_pending_mfa(final_response))
+
+        if f"{BASE_URL}/home" in final_response.url:
+            return self._fetch_auth_token()
+
+        if not _is_keycloak_url(final_response.url):
+            try:
+                return self._complete_oidc_session(final_response)
+            except MfaFailedError:
+                pass
+
+        raise InvalidAuthError(
+            "OrlenID rejected credentials — username or password is incorrect"
+        )

--- a/custom_components/pgnig_gas_sensor/config_flow.py
+++ b/custom_components/pgnig_gas_sensor/config_flow.py
@@ -1,120 +1,350 @@
-from typing import Optional, Dict, Any
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from .auth import AuthRegistry
-from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
+from .auth.exceptions import MfaFailedError, MfaRequired, MfaSessionExpiredError
+from .const import (
+    AUTH_METHOD_ORLEN_ID,
+    CONF_AUTH_METHOD,
+    CONF_MFA_CODE,
+    CONF_ORLEN_SESSION,
+    DEFAULT_AUTH_METHOD,
+    DOMAIN,
+)
 from .PgnigApi import PgnigApi
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
+    def __init__(self) -> None:
+        self._pending_mfa: dict[str, Any] | None = None
+        self._login_context: dict[str, Any] | None = None
+        self._authenticated_api: PgnigApi | None = None
+
     async def async_step_import(self, import_config):
         return self.async_abort(reason="one_instance_at_a_time_please")
 
-    async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None):
-        errors: Dict[str, str] = {}
-        description_placeholders: Dict[str, str] = {"error_info": ""}
+    def _credentials_schema(
+        self,
+        methods: list,
+        auth_method_default: str | None = None,
+    ) -> vol.Schema:
+        schema_dict: dict[Any, Any] = {}
+        if len(methods) > 1:
+            options = [(m.id, m.name) for m in methods]
+            if auth_method_default is not None:
+                schema_dict[vol.Required(CONF_AUTH_METHOD, default=auth_method_default)] = vol.In(
+                    dict(options)
+                )
+            else:
+                schema_dict[vol.Required(CONF_AUTH_METHOD)] = vol.In(dict(options))
+        schema_dict[vol.Required(CONF_USERNAME)] = cv.string
+        schema_dict[vol.Required(CONF_PASSWORD)] = cv.string
+        return vol.Schema(schema_dict)
+
+    def _store_login_context(
+        self,
+        *,
+        mode: str,
+        username: str,
+        password: str,
+        auth_method: str,
+        entry_id: str | None = None,
+        pending_mfa: dict[str, Any],
+    ) -> None:
+        self._pending_mfa = pending_mfa
+        self._login_context = {
+            "mode": mode,
+            "username": username,
+            "password": password,
+            "auth_method": auth_method,
+            "entry_id": entry_id,
+        }
+
+    async def _perform_login(
+        self,
+        username: str,
+        password: str,
+        auth_method: str,
+    ) -> None:
+        api = PgnigApi(username, password, auth_method)
+        await self.hass.async_add_executor_job(api.login)
+        self._authenticated_api = api
+
+    async def _perform_mfa(self, code: str) -> None:
+        if not self._pending_mfa or not self._login_context:
+            raise RuntimeError("MFA state missing from config flow")
+
+        api = PgnigApi(
+            self._login_context["username"],
+            self._login_context["password"],
+            self._login_context["auth_method"],
+        )
+        await self.hass.async_add_executor_job(
+            api.complete_mfa, self._pending_mfa, code
+        )
+        self._authenticated_api = api
+
+    def _entry_data(self) -> dict[str, Any]:
+        if not self._login_context:
+            raise RuntimeError("Login context missing from config flow")
+        data: dict[str, Any] = {
+            CONF_USERNAME: self._login_context["username"],
+            CONF_PASSWORD: self._login_context["password"],
+            CONF_AUTH_METHOD: self._login_context["auth_method"],
+        }
+        if self._authenticated_api:
+            session = self._authenticated_api.export_orlen_session()
+            if session:
+                data[CONF_ORLEN_SESSION] = session
+        return data
+
+    async def _finalize_success(self):
+        if not self._login_context:
+            raise RuntimeError("Login context missing from config flow")
+
+        mode = self._login_context["mode"]
+        data = self._entry_data()
+        self._pending_mfa = None
+        self._login_context = None
+        self._authenticated_api = None
+
+        if mode == "user":
+            return self.async_create_entry(title="Pgnig sensor", data=data)
+
+        entry_id = self.context.get("entry_id")
+        config_entry = (
+            self.hass.config_entries.async_get_entry(entry_id) if entry_id else None
+        )
+        if config_entry is None:
+            return self.async_abort(reason="no_config_entry")
+
+        self.hass.config_entries.async_update_entry(config_entry, data=data)
+        await self.hass.config_entries.async_reload(config_entry.entry_id)
+        if mode == "reauth":
+            return self.async_abort(reason="reauth_successful")
+        return self.async_abort(reason="reconfigure_successful")
+
+    async def _handle_login_exception(
+        self,
+        exc: Exception,
+        *,
+        mode: str,
+        username: str,
+        password: str,
+        auth_method: str,
+        entry_id: str | None = None,
+    ):
+        if isinstance(exc, MfaRequired):
+            if auth_method != AUTH_METHOD_ORLEN_ID:
+                return "verify_connection_failed", "MFA is only supported for OrlenID"
+            self._store_login_context(
+                mode=mode,
+                username=username,
+                password=password,
+                auth_method=auth_method,
+                entry_id=entry_id,
+                pending_mfa=exc.pending,
+            )
+            return await self.async_step_mfa()
+
+        _LOGGER.exception("Orlen EBOK login failed during %s", mode)
+        message = str(exc).strip() or "EBOK Login Failed"
+        return "verify_connection_failed", message
+
+    async def _return_to_credentials_after_mfa_expiry(self):
+        """Restart config flow from login/password after MFA session was reset."""
+        if not self._login_context:
+            return self.async_abort(reason="no_config_entry")
+
+        mode = self._login_context["mode"]
+        username = self._login_context["username"]
+        auth_method = self._login_context["auth_method"]
+        entry_id = self._login_context.get("entry_id")
+        self._pending_mfa = None
+
+        errors = {"base": "mfa_session_expired"}
+        description_placeholders = {
+            "error_info": (
+                "The MFA session expired (for example after several wrong codes). "
+                "Log in again with username and password, then enter the latest SMS code."
+            )
+        }
+        methods = AuthRegistry.list()
+
+        if mode == "user":
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self._credentials_schema(methods),
+                errors=errors,
+                description_placeholders=description_placeholders,
+            )
+
+        current_method = auth_method
+        config_entry = None
+        if entry_id:
+            config_entry = self.hass.config_entries.async_get_entry(entry_id)
+            if config_entry:
+                current_method = config_entry.data.get(CONF_AUTH_METHOD, auth_method)
+
+        step_id = "reauth" if mode == "reauth" else "reconfigure"
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=self._credentials_schema(methods, current_method),
+            errors=errors,
+            description_placeholders=description_placeholders,
+        )
+
+    async def async_step_mfa(self, user_input: Optional[dict[str, Any]] = None):
+        errors: dict[str, str] = {}
+        description_placeholders = {"error_info": ""}
+
+        if self._pending_mfa is None or self._login_context is None:
+            return self.async_abort(reason="no_config_entry")
+
+        if user_input is not None:
+            try:
+                await self._perform_mfa(user_input[CONF_MFA_CODE])
+                return await self._finalize_success()
+            except MfaSessionExpiredError as exc:
+                return await self._return_to_credentials_after_mfa_expiry()
+            except MfaFailedError as exc:
+                errors = {"base": "mfa_failed"}
+                description_placeholders = {"error_info": str(exc)}
+            except Exception as exc:
+                _LOGGER.exception("OrlenID MFA verification failed")
+                errors = {"base": "mfa_failed"}
+                description_placeholders = {"error_info": str(exc) or "MFA verification failed"}
+
+        return self.async_show_form(
+            step_id="mfa",
+            data_schema=vol.Schema({vol.Required(CONF_MFA_CODE): cv.string}),
+            errors=errors,
+            description_placeholders=description_placeholders,
+        )
+
+    async def async_step_user(self, user_input: Optional[dict[str, Any]] = None):
+        errors: dict[str, str] = {}
+        description_placeholders = {"error_info": ""}
         methods = AuthRegistry.list()
 
         if user_input is not None:
             auth_method = user_input.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
-            username = user_input.get(CONF_USERNAME)
-            password = user_input.get(CONF_PASSWORD)
-
-            api = PgnigApi(username, password, auth_method)
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
             try:
-                await self.hass.async_add_executor_job(api.login)
-                data = {
-                    CONF_USERNAME: username,
-                    CONF_PASSWORD: password,
-                    CONF_AUTH_METHOD: auth_method,
-                }
-                return self.async_create_entry(title="Pgnig sensor", data=data)
-            except Exception:
-                errors = {"base": "verify_connection_failed"}
-                description_placeholders = {"error_info": "EBOK Login Failed"}
-
-        schema_dict: Dict[str, Any] = {}
-        if len(methods) > 1:
-            options = [(m.id, m.name) for m in methods]
-            schema_dict[vol.Required(CONF_AUTH_METHOD)] = vol.In(dict(options))
-        schema_dict[vol.Required(CONF_USERNAME)] = cv.string
-        schema_dict[vol.Required(CONF_PASSWORD)] = cv.string
+                await self._perform_login(username, password, auth_method)
+                return self.async_create_entry(
+                    title="Pgnig sensor",
+                    data={
+                        CONF_USERNAME: username,
+                        CONF_PASSWORD: password,
+                        CONF_AUTH_METHOD: auth_method,
+                    },
+                )
+            except Exception as exc:
+                result = await self._handle_login_exception(
+                    exc,
+                    mode="user",
+                    username=username,
+                    password=password,
+                    auth_method=auth_method,
+                )
+                if not isinstance(result, tuple):
+                    return result
+                errors = {"base": result[0]}
+                description_placeholders = {"error_info": result[1]}
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(schema_dict),
+            data_schema=self._credentials_schema(methods),
             errors=errors,
             description_placeholders=description_placeholders,
         )
 
-    async def async_step_reauth(self, user_input: Optional[Dict[str, Any]] = None):
-        errors: Dict[str, str] = {}
-        description_placeholders: Dict[str, str] = {"error_info": ""}
+    async def async_step_reauth(self, user_input: Optional[dict[str, Any]] = None):
+        errors: dict[str, str] = {}
+        description_placeholders = {"error_info": ""}
         methods = AuthRegistry.list()
-
         entry_id = self.context.get("entry_id")
-        config_entry = self.hass.config_entries.async_get_entry(entry_id) if entry_id else None
+        config_entry = (
+            self.hass.config_entries.async_get_entry(entry_id) if entry_id else None
+        )
 
         if user_input is not None and config_entry:
-            auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
+            auth_method = user_input.get(
+                CONF_AUTH_METHOD,
+                config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD),
+            )
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
             try:
-                api = PgnigApi(
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PASSWORD],
-                    auth_method,
-                )
-                await self.hass.async_add_executor_job(api.login)
-
+                await self._perform_login(username, password, auth_method)
                 self.hass.config_entries.async_update_entry(
                     config_entry,
                     data={
                         **config_entry.data,
-                        CONF_USERNAME: user_input[CONF_USERNAME],
-                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        CONF_USERNAME: username,
+                        CONF_PASSWORD: password,
+                        CONF_AUTH_METHOD: auth_method,
                     },
                 )
                 await self.hass.config_entries.async_reload(entry_id)
                 return self.async_abort(reason="reauth_successful")
-            except Exception:
-                errors["base"] = "verify_connection_failed"
-                description_placeholders["error_info"] = "Login Failed"
+            except Exception as exc:
+                result = await self._handle_login_exception(
+                    exc,
+                    mode="reauth",
+                    username=username,
+                    password=password,
+                    auth_method=auth_method,
+                    entry_id=entry_id,
+                )
+                if not isinstance(result, tuple):
+                    return result
+                errors = {"base": result[0]}
+                description_placeholders = {"error_info": result[1]}
 
-        schema_dict: Dict[str, Any] = {}
-        if len(methods) > 1 and config_entry:
-            current_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
-            options = [(m.id, m.name) for m in methods]
-            schema_dict[vol.Required(CONF_AUTH_METHOD, default=current_method)] = vol.In(dict(options))
-        schema_dict[vol.Required(CONF_USERNAME)] = cv.string
-        schema_dict[vol.Required(CONF_PASSWORD)] = cv.string
-
+        current_method = (
+            config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
+            if config_entry
+            else DEFAULT_AUTH_METHOD
+        )
         return self.async_show_form(
             step_id="reauth",
-            data_schema=vol.Schema(schema_dict),
+            data_schema=self._credentials_schema(methods, current_method),
             errors=errors,
             description_placeholders=description_placeholders,
         )
 
-    async def async_step_reconfigure(self, user_input: Optional[Dict[str, Any]] = None):
+    async def async_step_reconfigure(self, user_input: Optional[dict[str, Any]] = None):
         methods = AuthRegistry.list()
         entry_id = self.context.get("entry_id")
-        config_entry = self.hass.config_entries.async_get_entry(entry_id) if entry_id else None
+        config_entry = (
+            self.hass.config_entries.async_get_entry(entry_id) if entry_id else None
+        )
 
         if config_entry is None:
             return self.async_abort(reason="no_config_entry")
 
+        errors: dict[str, str] = {}
+        description_placeholders = {"error_info": ""}
+        current_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
+
         if user_input is not None:
-            auth_method = user_input.get(CONF_AUTH_METHOD, config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD))
-            username = user_input.get(CONF_USERNAME)
-            password = user_input.get(CONF_PASSWORD)
-
+            auth_method = user_input.get(CONF_AUTH_METHOD, current_method)
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
             try:
-                api = PgnigApi(username, password, auth_method)
-                await self.hass.async_add_executor_job(api.login)
-
+                await self._perform_login(username, password, auth_method)
                 self.hass.config_entries.async_update_entry(
                     config_entry,
                     data={
@@ -124,26 +354,24 @@ class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
                     },
                 )
                 await self.hass.config_entries.async_reload(config_entry.entry_id)
-
                 return self.async_abort(reason="reconfigure_successful")
-            except Exception:
-                errors = {"base": "verify_connection_failed"}
-                description_placeholders = {"error_info": "Login Failed"}
-        else:
-            errors = {}
-            description_placeholders = {"error_info": ""}
-
-        current_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
-        schema_dict: Dict[str, Any] = {}
-        if len(methods) > 1:
-            options = [(m.id, m.name) for m in methods]
-            schema_dict[vol.Required(CONF_AUTH_METHOD, default=current_method)] = vol.In(dict(options))
-        schema_dict[vol.Required(CONF_USERNAME)] = cv.string
-        schema_dict[vol.Required(CONF_PASSWORD)] = cv.string
+            except Exception as exc:
+                result = await self._handle_login_exception(
+                    exc,
+                    mode="reconfigure",
+                    username=username,
+                    password=password,
+                    auth_method=auth_method,
+                    entry_id=entry_id,
+                )
+                if not isinstance(result, tuple):
+                    return result
+                errors = {"base": result[0]}
+                description_placeholders = {"error_info": result[1]}
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=vol.Schema(schema_dict),
+            data_schema=self._credentials_schema(methods, current_method),
             errors=errors,
             description_placeholders=description_placeholders,
         )

--- a/custom_components/pgnig_gas_sensor/const.py
+++ b/custom_components/pgnig_gas_sensor/const.py
@@ -2,4 +2,7 @@
 
 DOMAIN = "pgnig_gas_sensor"
 CONF_AUTH_METHOD = "auth_method"
+CONF_MFA_CODE = "mfa_code"
+CONF_ORLEN_SESSION = "orlen_session"
 DEFAULT_AUTH_METHOD = "api_login"
+AUTH_METHOD_ORLEN_ID = "orlen_id"

--- a/custom_components/pgnig_gas_sensor/diagnostics.py
+++ b/custom_components/pgnig_gas_sensor/diagnostics.py
@@ -8,14 +8,14 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
+from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD, CONF_ORLEN_SESSION
 from .PgnigApi import PgnigApi
 from .Invoices import InvoicesList
 from .PpgReadingForMeter import MeterReading
 
 _LOGGER = logging.getLogger(__name__)
 
-TO_REDACT = {"username", "password"}
+TO_REDACT = {"username", "password", CONF_ORLEN_SESSION, "token", "cookies"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -27,7 +27,8 @@ async def async_get_config_entry_diagnostics(
     password = config_entry.data.get("password")
     auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
 
-    api = PgnigApi(username, password, auth_method)
+    session_data = config_entry.data.get(CONF_ORLEN_SESSION)
+    api = PgnigApi(username, password, auth_method, session_data=session_data)
 
     meters = await hass.async_add_executor_job(api.meterList)
     invoices = await hass.async_add_executor_job(api.invoices)

--- a/custom_components/pgnig_gas_sensor/manifest.json
+++ b/custom_components/pgnig_gas_sensor/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [],
   "iot_class": "cloud_polling",
   "quality_scale": "gold",
-  "version": "2.4.0"
+  "version": "2.5.0"
 }

--- a/custom_components/pgnig_gas_sensor/sensor.py
+++ b/custom_components/pgnig_gas_sensor/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from .Invoices import InvoicesList
 from .PgnigApi import PgnigApi
 from .PpgReadingForMeter import MeterReading
-from .const import CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -33,10 +33,7 @@ async def async_setup_entry(
         config_entry: ConfigEntry,
         async_add_entities,
 ):
-    user = config_entry.data[CONF_USERNAME]
-    password = config_entry.data[CONF_PASSWORD]
-    auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
-    api = PgnigApi(user, password, auth_method)
+    api = hass.data[DOMAIN][config_entry.entry_id]
     try:
         pgps = await hass.async_add_executor_job(api.meterList)
     except Exception as err:

--- a/custom_components/pgnig_gas_sensor/strings.json
+++ b/custom_components/pgnig_gas_sensor/strings.json
@@ -6,7 +6,16 @@
         "title": "Select login method",
         "description": "Choose how to log in to your Orlen EBOK account.",
         "data": {
-          "auth_method": "Login method"
+          "auth_method": "Login method",
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "mfa": {
+        "title": "Enter MFA code",
+        "description": "OrlenID sent a verification code to your phone. Enter the SMS code to finish login.\n\n\n\n {error_info}",
+        "data": {
+          "mfa_code": "SMS / MFA code"
         }
       },
       "credentials": {
@@ -21,6 +30,7 @@
         "title": "Update credentials for Orlen EBOK",
         "description": "Your login credentials are invalid. Please update them. \n\n\n\n {error_info}",
         "data": {
+          "auth_method": "Login method",
           "username": "Username",
           "password": "Password"
         }
@@ -36,7 +46,9 @@
       }
     },
     "error": {
-      "verify_connection_failed": "Login failed!"
+      "verify_connection_failed": "Login failed!",
+      "mfa_failed": "Invalid or expired MFA code",
+      "mfa_session_expired": "MFA session expired — log in again with password, then enter the latest SMS code"
     },
     "abort": {
       "reauth_successful": "Credentials updated successfully",

--- a/custom_components/pgnig_gas_sensor/translations/en.json
+++ b/custom_components/pgnig_gas_sensor/translations/en.json
@@ -6,7 +6,16 @@
         "title": "Select login method",
         "description": "Choose how to log in to your Orlen EBOK account.",
         "data": {
-          "auth_method": "Login method"
+          "auth_method": "Login method",
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "mfa": {
+        "title": "Enter MFA code",
+        "description": "OrlenID sent a verification code to your phone. Enter the SMS code to finish login.\n\n\n\n {error_info}",
+        "data": {
+          "mfa_code": "SMS / MFA code"
         }
       },
       "credentials": {
@@ -21,6 +30,7 @@
         "title": "Update credentials for Orlen EBOK",
         "description": "Your login credentials are invalid. Please update them. \n\n\n\n {error_info}",
         "data": {
+          "auth_method": "Login method",
           "username": "Username",
           "password": "Password"
         }
@@ -36,7 +46,9 @@
       }
     },
     "error": {
-      "verify_connection_failed": "Login failed!"
+      "verify_connection_failed": "Login failed!",
+      "mfa_failed": "Invalid or expired MFA code",
+      "mfa_session_expired": "MFA session expired — log in again with password, then enter the latest SMS code"
     },
     "abort": {
       "reauth_successful": "Credentials updated successfully",

--- a/custom_components/pgnig_gas_sensor/translations/pl.json
+++ b/custom_components/pgnig_gas_sensor/translations/pl.json
@@ -6,7 +6,16 @@
         "title": "Wybierz metodę logowania",
         "description": "Wybierz jak logować się do swojego konta Orlen EBOK.",
         "data": {
-          "auth_method": "Metoda logowania"
+          "auth_method": "Metoda logowania",
+          "username": "Login",
+          "password": "Hasło"
+        }
+      },
+      "mfa": {
+        "title": "Wpisz kod MFA",
+        "description": "OrlenID wysłał kod weryfikacyjny na Twój telefon. Wpisz kod SMS, aby dokończyć logowanie.\n\n\n\n {error_info}",
+        "data": {
+          "mfa_code": "Kod SMS / MFA"
         }
       },
       "credentials": {
@@ -21,6 +30,7 @@
         "title": "Zaktualizuj dane logowania do Orlen EBOK",
         "description": "Twoje dane logowania są nieprawidłowe. Zaktualizuj je. \n\n\n\n {error_info}",
         "data": {
+          "auth_method": "Metoda logowania",
           "username": "Login",
           "password": "Hasło"
         }
@@ -36,7 +46,9 @@
       }
     },
     "error": {
-      "verify_connection_failed": "Logowanie nie powiodło się!"
+      "verify_connection_failed": "Logowanie nie powiodło się!",
+      "mfa_failed": "Nieprawidłowy lub wygasły kod MFA",
+      "mfa_session_expired": "Sesja MFA wygasła — zaloguj się ponownie hasłem, potem wpisz najnowszy kod SMS"
     },
     "abort": {
       "reauth_successful": "Dane logowania zaktualizowane pomyślnie",

--- a/tests/test_orlen_id_mfa.py
+++ b/tests/test_orlen_id_mfa.py
@@ -6,7 +6,7 @@ import requests
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from custom_components.pgnig_gas_sensor.auth.exceptions import MfaRequired
+from custom_components.pgnig_gas_sensor.auth.exceptions import MfaRequired, MfaSessionExpiredError
 from custom_components.pgnig_gas_sensor.auth.orlen_id import (
     OrlenIDAuth,
     _build_mfa_payload,
@@ -136,6 +136,48 @@ async def test_config_flow_mfa_step_after_mfa_required(hass):
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_ORLEN_SESSION]["token"] == "token-xyz"
     mock_api.complete_mfa.assert_called_once_with(pending, "123456")
+
+
+@pytest.mark.asyncio
+async def test_config_flow_returns_to_user_on_mfa_session_expired(hass):
+    pending = {
+        "username": "user@test.pl",
+        "password": "secret",
+        "device_id": "device123",
+        "cookies": [],
+        "mfa_post_url": "https://oid-ws.orlen.pl/auth",
+        "mfa_form_fields": {},
+        "mfa_field_name": "code",
+        "mfa_referer": "https://oid-ws.orlen.pl/",
+    }
+
+    with patch("custom_components.pgnig_gas_sensor.config_flow.PgnigApi") as mock_api_cls:
+        mock_api = MagicMock()
+        mock_api.login.side_effect = MfaRequired(pending)
+        mock_api.complete_mfa.side_effect = MfaSessionExpiredError("session expired")
+        mock_api_cls.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_AUTH_METHOD: AUTH_METHOD_ORLEN_ID,
+                CONF_USERNAME: "user@test.pl",
+                CONF_PASSWORD: "secret",
+            },
+        )
+        assert result["step_id"] == "mfa"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_MFA_CODE: "999999"},
+        )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"]["base"] == "mfa_session_expired"
 
 
 def test_build_pending_mfa_from_sms_response():

--- a/tests/test_orlen_id_mfa.py
+++ b/tests/test_orlen_id_mfa.py
@@ -1,0 +1,150 @@
+"""Tests for OrlenID MFA helpers and config flow step."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from custom_components.pgnig_gas_sensor.auth.exceptions import MfaRequired
+from custom_components.pgnig_gas_sensor.auth.orlen_id import (
+    OrlenIDAuth,
+    _build_mfa_payload,
+    _cookies_for_storage,
+    _find_mfa_form,
+    _restore_cookies,
+)
+from custom_components.pgnig_gas_sensor.const import (
+    AUTH_METHOD_ORLEN_ID,
+    CONF_AUTH_METHOD,
+    CONF_MFA_CODE,
+    CONF_ORLEN_SESSION,
+    DOMAIN,
+)
+
+SMS_FORM_HTML = """
+<form action="https://oid-ws.orlen.pl/realms/oid/login-actions/authenticate?session_code=abc"
+      method="post">
+  <input type="text" id="code" name="code" />
+  <input type="submit" value="Submit" />
+</form>
+"""
+
+OTP_FORM_HTML = """
+<form action="https://oid-ws.orlen.pl/realms/oid/login-actions/authenticate?session_code=xyz"
+      method="post">
+  <input type="text" name="otp" />
+  <input name="login" type="submit" value="Log In" />
+</form>
+"""
+
+
+def test_find_mfa_form_detects_sms_code_field():
+    action, fields, field_name = _find_mfa_form(
+        SMS_FORM_HTML, "https://oid-ws.orlen.pl/"
+    )
+    assert "authenticate" in action
+    assert field_name == "code"
+    assert fields == {}
+
+
+def test_find_mfa_form_detects_otp_field():
+    action, fields, field_name = _find_mfa_form(
+        OTP_FORM_HTML, "https://oid-ws.orlen.pl/"
+    )
+    assert field_name == "otp"
+    assert fields["login"] == "Log In"
+
+
+def test_build_mfa_payload_for_sms_does_not_add_login():
+    payload = _build_mfa_payload({}, "code", "123456")
+    assert payload == {"code": "123456"}
+    assert "login" not in payload
+
+
+def test_build_mfa_payload_for_otp_adds_login_submit():
+    payload = _build_mfa_payload({}, "otp", "123456")
+    assert payload == {"otp": "123456", "login": "Log In"}
+
+
+def test_cookie_storage_roundtrip_preserves_values():
+    session = requests.Session()
+    session.cookies.set("KEYCLOAK_SESSION", "abc", domain="oid-ws.orlen.pl", path="/")
+    session.cookies.set("pgnig-ebok-device-token", "device123")
+
+    stored = _cookies_for_storage(session.cookies)
+    restored = requests.Session()
+    _restore_cookies(restored, stored)
+
+    assert restored.cookies.get("KEYCLOAK_SESSION") == "abc"
+    assert restored.cookies.get("pgnig-ebok-device-token") == "device123"
+
+
+def test_export_session_contains_token_and_cookies():
+    auth = OrlenIDAuth("user@test.pl", "secret")
+    auth._cached_token = "token-xyz"
+    auth._session.cookies.set("session", "value", domain="oid-ws.orlen.pl", path="/")
+
+    exported = auth.export_session()
+    assert exported["token"] == "token-xyz"
+    assert exported["device_id"]
+    assert any(cookie["name"] == "session" for cookie in exported["cookies"])
+
+
+@pytest.mark.asyncio
+async def test_config_flow_mfa_step_after_mfa_required(hass):
+    pending = {
+        "username": "user@test.pl",
+        "password": "secret",
+        "device_id": "device123",
+        "cookies": [],
+        "mfa_post_url": "https://oid-ws.orlen.pl/auth",
+        "mfa_form_fields": {},
+        "mfa_field_name": "code",
+        "mfa_referer": "https://oid-ws.orlen.pl/",
+    }
+
+    with patch("custom_components.pgnig_gas_sensor.config_flow.PgnigApi") as mock_api_cls:
+        mock_api = MagicMock()
+        mock_api.login.side_effect = MfaRequired(pending)
+        mock_api.export_orlen_session.return_value = {
+            "device_id": "device123",
+            "cookies": [],
+            "token": "token-xyz",
+        }
+        mock_api_cls.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_AUTH_METHOD: AUTH_METHOD_ORLEN_ID,
+                CONF_USERNAME: "user@test.pl",
+                CONF_PASSWORD: "secret",
+            },
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "mfa"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_MFA_CODE: "123456"},
+        )
+
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_ORLEN_SESSION]["token"] == "token-xyz"
+    mock_api.complete_mfa.assert_called_once_with(pending, "123456")
+
+
+def test_build_pending_mfa_from_sms_response():
+    auth = OrlenIDAuth("user@test.pl", "secret")
+    response = MagicMock()
+    response.text = SMS_FORM_HTML
+    response.url = "https://oid-ws.orlen.pl/realms/oid/login-actions/authenticate"
+
+    pending = auth._build_pending_mfa(response)
+    assert pending["mfa_field_name"] == "code"
+    assert pending["username"] == "user@test.pl"
+    assert isinstance(pending["cookies"], list)


### PR DESCRIPTION
Fixes #91

## PL — podsumowanie

Dodaje obsługę uwierzytelniania dwuskładnikowego (SMS/OTP) dla logowania OrlenID w Home Assistant.

- Nowy krok konfiguracji: **„Wpisz kod MFA”** (setup, rekonfiguracja, ponowne logowanie)
- Obsługa formularza SMS Keycloak (`code`) oraz standardowego OTP (`otp`)
- Zapis sesji OrlenID po udanym MFA (cookies + token API), żeby nie wysyłać SMS przy każdym starcie HA
- Naprawa podwójnego logowania przy setupie sensorów
- Naprawa `unload` integracji w HA 2026 (`has_service` zamiast `async_has_service`)
- Redakcja `orlen_session` w diagnostyce (brak wycieku tokenów/cookies)
- Testy jednostkowe: `tests/test_orlen_id_mfa.py`

Przetestowane na HAOS 2026.6 z prawdziwym kontem OrlenID + MFA SMS.

## EN — summary

Adds SMS/OTP MFA support for OrlenID login in Home Assistant.

- New config flow step for MFA code entry (initial setup, reconfigure, reauth)
- Keycloak SMS form (`code`) and standard OTP (`otp`) support
- Persists OrlenID session after MFA (cookies + API token) to avoid SMS on every HA restart
- Fixes duplicate login during platform setup
- Fixes integration unload on HA 2026 (`has_service` instead of `async_has_service`)
- Redacts `orlen_session` from diagnostics downloads
- Unit tests in `tests/test_orlen_id_mfa.py`

Tested on HAOS 2026.6 with a real OrlenID account and SMS MFA.

## Test plan / plan testów

- [x] OrlenID login + MFA SMS — initial config flow
- [x] Sensors appear after successful MFA
- [x] CI (`pytest`)
- [x] Reconfigure / reauth with MFA
- [x] Session restore after HA restart (no new SMS while session is valid)