### PR TITLE
test: fix CI mocks for OrlenID MFA helpers and login flow

### DIFF
--- a/tests/test_orlen_id.py
+++ b/tests/test_orlen_id.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 from custom_components.pgnig_gas_sensor.auth import AuthRegistry
+from custom_components.pgnig_gas_sensor.auth.exceptions import InvalidAuthError
 
 
 def _mock_resp(json_data=None, status_code=200, text=""):
@@ -51,60 +52,74 @@ def test_login_returns_cached_token(auth):
 
 
 def test_login_full_flow_success(auth):
-    with patch.object(auth, "_session") as mock_session:
-        mock_session.get.return_value = _mock_resp(
-            text='<form action="https://oid.example.com/auth?execution=123&tab_id=abc">'
-        )
-        mock_session.post.return_value = _mock_resp(status_code=200)
-        mock_session.post.return_value.url = "https://ebok.myorlen.pl/home"
+    with patch.object(auth, "_session") as mock_session, patch.object(
+        auth, "_try_restore_session_token", return_value=None
+    ):
         auth._device_id = "mocked-device-id"
         mock_token_resp = _mock_resp({"Token": "oid-token-xyz"}, status_code=200)
+        cred_resp = _mock_resp(status_code=200)
+        cred_resp.url = "https://ebok.myorlen.pl/home"
+        mock_session.post.side_effect = [
+            _mock_resp({"RedirectUrl": "https://oid.example.com/auth"}, status_code=200),
+            cred_resp,
+        ]
         mock_session.get.side_effect = [
             _mock_resp(status_code=200),
             _mock_resp(text='<form action="https://oid.example.com/auth">'),
             mock_token_resp,
         ]
-        mock_session.post.return_value = _mock_resp(status_code=200)
-        mock_session.post.return_value.url = "https://ebok.myorlen.pl/home"
-        mock_session.post.return_value.status_code = 302
-        mock_session.post.return_value.ok = True
         token = auth.login()
         assert token == "oid-token-xyz"
         assert auth._cached_token == "oid-token-xyz"
 
 
-def test_login_returns_empty_when_form_not_found(auth):
-    with patch.object(auth, "_session") as mock_session:
-        mock_session.get.return_value = _mock_resp(
-            text="<html>No form here</html>"
+def test_login_raises_when_login_form_missing(auth):
+    with patch.object(auth, "_session") as mock_session, patch.object(
+        auth, "_try_restore_session_token", return_value=None
+    ):
+        mock_session.post.return_value = _mock_resp(
+            {"RedirectUrl": "https://oid.example.com/auth"}, status_code=200
         )
-        mock_session.post.return_value = _mock_resp(status_code=200)
-        mock_session.post.return_value.url = "https://ebok.myorlen.pl/login"
-        assert auth.login() == ""
-
-
-def test_login_returns_empty_when_not_redirected_to_home(auth):
-    with patch.object(auth, "_session") as mock_session:
-        mock_session.get.return_value = _mock_resp(
-            text='<form action="https://oid.example.com/auth?execution=123">'
-        )
-        mock_session.post.return_value = _mock_resp(status_code=200)
-        mock_session.post.return_value.url = "https://ebok.myorlen.pl/login?error=1"
-        assert auth.login() == ""
-
-
-def test_get_auth_token_fails_returns_empty(auth):
-    with patch.object(auth, "_session") as mock_session:
-        mock_session.get.return_value = _mock_resp(
-            text='<form action="https://oid.example.com/auth">'
-        )
-        mock_session.post.return_value.url = "https://ebok.myorlen.pl/home"
-        mock_session.post.return_value.status_code = 302
-        mock_session.post.return_value.ok = True
         mock_session.get.side_effect = [
             _mock_resp(status_code=200),
-            _mock_resp(text="some page"),
-            _mock_resp(status_code=401),
+            _mock_resp(text="<html>No form here</html>"),
         ]
-        mock_session.post.return_value = _mock_resp(status_code=200)
-        assert auth.login() == ""
+        with pytest.raises(RuntimeError, match="login form not found"):
+            auth.login()
+
+
+def test_login_raises_invalid_auth_when_not_redirected_to_home(auth):
+    with patch.object(auth, "_session") as mock_session, patch.object(
+        auth, "_try_restore_session_token", return_value=None
+    ):
+        cred_resp = _mock_resp(status_code=200)
+        cred_resp.url = "https://oid-ws.orlen.pl/login-actions/authenticate"
+        mock_session.post.side_effect = [
+            _mock_resp({"RedirectUrl": "https://oid.example.com/auth"}, status_code=200),
+            cred_resp,
+        ]
+        mock_session.get.side_effect = [
+            _mock_resp(status_code=200),
+            _mock_resp(text='<form action="https://oid.example.com/auth">'),
+        ]
+        with pytest.raises(InvalidAuthError):
+            auth.login()
+
+
+def test_login_raises_when_auth_token_request_fails(auth):
+    with patch.object(auth, "_session") as mock_session, patch.object(
+        auth, "_try_restore_session_token", return_value=None
+    ):
+        cred_resp = _mock_resp(status_code=200)
+        cred_resp.url = "https://ebok.myorlen.pl/home"
+        mock_session.post.side_effect = [
+            _mock_resp({"RedirectUrl": "https://oid.example.com/auth"}, status_code=200),
+            cred_resp,
+        ]
+        mock_session.get.side_effect = [
+            _mock_resp(status_code=200),
+            _mock_resp(text='<form action="https://oid.example.com/auth">'),
+            _mock_resp(status_code=401, text="unauthorized"),
+        ]
+        with pytest.raises(RuntimeError, match="Auth token"):
+            auth.login()

--- a/tests/test_orlen_id_mfa.py
+++ b/tests/test_orlen_id_mfa.py
@@ -23,6 +23,7 @@ from custom_components.pgnig_gas_sensor.const import (
 )
 
 SMS_FORM_HTML = """
+<p>Wpisz kod SMS weryfikacyjny</p>
 <form action="https://oid-ws.orlen.pl/realms/oid/login-actions/authenticate?session_code=abc"
       method="post">
   <input type="text" id="code" name="code" />
@@ -37,6 +38,11 @@ OTP_FORM_HTML = """
   <input name="login" type="submit" value="Log In" />
 </form>
 """
+
+
+@pytest.fixture(autouse=True)
+def auto_enable(enable_custom_integrations):
+    yield
 
 
 def test_find_mfa_form_detects_sms_code_field():
@@ -78,6 +84,15 @@ def test_cookie_storage_roundtrip_preserves_values():
 
     assert restored.cookies.get("KEYCLOAK_SESSION") == "abc"
     assert restored.cookies.get("pgnig-ebok-device-token") == "device123"
+
+
+def test_restore_cookies_handles_empty_domain():
+    session = requests.Session()
+    _restore_cookies(
+        session,
+        [{"name": "KEYCLOAK_SESSION", "value": "abc", "domain": "", "path": "/"}],
+    )
+    assert session.cookies.get("KEYCLOAK_SESSION") == "abc"
 
 
 def test_export_session_contains_token_and_cookies():


### PR DESCRIPTION
- Add MFA keyword text to SMS fixture HTML so form detection passes
- Register custom integration in MFA config flow tests
- Update OrlenID login tests for exception-based auth errors