### PR TITLE
fix: retry API calls on expired auth token (401)

### DIFF
--- a/custom_components/pgnig_gas_sensor/PgnigApi.py
+++ b/custom_components/pgnig_gas_sensor/PgnigApi.py
@@ -7,6 +7,7 @@ from .Invoices import invoices_from_dict, Invoices
 from .PgpList import PpgList, ppg_list_from_dict
 from .PpgReadingForMeter import PpgReadingForMeter, ppg_reading_for_meter_from_dict
 from .auth import AuthRegistry
+from .auth.exceptions import SessionExpiredError
 from .auth.orlen_id import OrlenIDAuth
 from .const import AUTH_METHOD_ORLEN_ID, DEFAULT_AUTH_METHOD
 
@@ -53,6 +54,22 @@ class PgnigApi:
     def invalidate_token(self) -> None:
         self._auth.invalidate_token()
 
+    def refresh_auth_token(self) -> str:
+        """Refresh EBOK API token using the current HTTP session (no MFA)."""
+        with self._login_lock:
+            if self._auth_method == AUTH_METHOD_ORLEN_ID and isinstance(
+                self._auth, OrlenIDAuth
+            ):
+                self.invalidate_token()
+                token = self._auth._try_restore_session_token()
+                if not token:
+                    raise SessionExpiredError(
+                        "OrlenID session expired; re-authenticate in Home Assistant"
+                    )
+                return token
+            self.invalidate_token()
+            return self._auth.login()
+
     def _get_authenticated(self, url: str, operation: str) -> requests.Response:
         last_response = None
         for attempt in range(2):
@@ -62,11 +79,13 @@ class PgnigApi:
                 )
                 self.invalidate_token()
 
-            token = self.login()
+            token = self.login(allow_interactive=False)
             if not token:
                 raise RuntimeError("Login failed - no token received")
 
-            resp = self._auth.session.get(url, headers=self._api_headers(token))
+            resp = self._auth.session.get(
+                url, headers=self._api_headers(token), timeout=30
+            )
             if resp.status_code == 401 and attempt == 0:
                 last_response = resp
                 continue
@@ -92,9 +111,15 @@ class PgnigApi:
         resp = self._get_authenticated(invoices_url, "Invoices")
         return invoices_from_dict(resp.json())
 
-    def login(self) -> str:
+    def login(self, *, allow_interactive: bool = False) -> str:
         with self._login_lock:
-            _LOGGER.debug("PgnigApi.login() delegating to %s", type(self._auth).__name__)
+            _LOGGER.debug(
+                "PgnigApi.login() delegating to %s", type(self._auth).__name__
+            )
+            if self._auth_method == AUTH_METHOD_ORLEN_ID and isinstance(
+                self._auth, OrlenIDAuth
+            ):
+                return self._auth.login(allow_interactive=allow_interactive)
             return self._auth.login()
 
     def export_orlen_session(self) -> dict | None:

--- a/custom_components/pgnig_gas_sensor/PgnigApi.py
+++ b/custom_components/pgnig_gas_sensor/PgnigApi.py
@@ -1,7 +1,10 @@
 import logging
+import threading
+
+import requests
 
 from .Invoices import invoices_from_dict, Invoices
-from .PgpList import (PpgList, ppg_list_from_dict)
+from .PgpList import PpgList, ppg_list_from_dict
 from .PpgReadingForMeter import PpgReadingForMeter, ppg_reading_for_meter_from_dict
 from .auth import AuthRegistry
 from .const import DEFAULT_AUTH_METHOD
@@ -9,12 +12,17 @@ from .const import DEFAULT_AUTH_METHOD
 _LOGGER = logging.getLogger(__name__)
 
 devices_list_url = "https://ebok.myorlen.pl/crm/get-ppg-list?api-version=3.0"
-readings_url = "https://ebok.myorlen.pl/crm/get-all-ppg-readings-for-meter?pageSize=10&pageNumber=1&api-version=3.0&idPpg="
-invoices_url = "https://ebok.myorlen.pl/crm/get-invoices-v2?pageNumber=1&pageSize=12&api-version=3.0"
+readings_url = (
+    "https://ebok.myorlen.pl/crm/get-all-ppg-readings-for-meter"
+    "?pageSize=10&pageNumber=1&api-version=3.0&idPpg="
+)
+invoices_url = (
+    "https://ebok.myorlen.pl/crm/get-invoices-v2"
+    "?pageNumber=1&pageSize=12&api-version=3.0"
+)
 
 
 class PgnigApi:
-
     def __init__(self, username, password, auth_method=DEFAULT_AUTH_METHOD) -> None:
         self.username = username
         self.password = password
@@ -22,41 +30,58 @@ class PgnigApi:
         if auth_class is None:
             raise ValueError(f"Unknown auth method: {auth_method}")
         self._auth = auth_class(username, password)
+        self._login_lock = threading.Lock()
 
     def _api_headers(self, token):
         return {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            'AuthToken': token,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "AuthToken": token,
         }
 
+    def invalidate_token(self) -> None:
+        self._auth.invalidate_token()
+
+    def _get_authenticated(self, url: str, operation: str) -> requests.Response:
+        last_response = None
+        for attempt in range(2):
+            if attempt > 0:
+                _LOGGER.debug(
+                    "%s returned 401, invalidating token and retrying", operation
+                )
+                self.invalidate_token()
+
+            token = self.login()
+            if not token:
+                raise RuntimeError("Login failed - no token received")
+
+            resp = self._auth.session.get(url, headers=self._api_headers(token))
+            if resp.status_code == 401 and attempt == 0:
+                last_response = resp
+                continue
+            if not resp.ok:
+                raise RuntimeError(
+                    f"{operation} failed with status {resp.status_code}: {resp.text[:200]}"
+                )
+            return resp
+
+        status = last_response.status_code if last_response else 401
+        body = last_response.text[:200] if last_response else ""
+        raise RuntimeError(f"{operation} failed with status {status}: {body}")
+
     def meterList(self) -> PpgList:
-        token = self.login()
-        if not token:
-            raise RuntimeError("Login failed - no token received")
-        resp = self._auth.session.get(devices_list_url, headers=self._api_headers(token))
-        if not resp.ok:
-            raise RuntimeError(f"Meter list failed with status {resp.status_code}: {resp.text[:200]}")
+        resp = self._get_authenticated(devices_list_url, "Meter list")
         return ppg_list_from_dict(resp.json())
 
     def readingForMeter(self, meter_id) -> PpgReadingForMeter:
-        token = self.login()
-        if not token:
-            raise RuntimeError("Login failed - no token received")
-        resp = self._auth.session.get(readings_url + meter_id, headers=self._api_headers(token))
-        if not resp.ok:
-            raise RuntimeError(f"Reading failed with status {resp.status_code}: {resp.text[:200]}")
+        resp = self._get_authenticated(readings_url + meter_id, "Reading")
         return ppg_reading_for_meter_from_dict(resp.json())
 
     def invoices(self) -> Invoices:
-        token = self.login()
-        if not token:
-            raise RuntimeError("Login failed - no token received")
-        resp = self._auth.session.get(invoices_url, headers=self._api_headers(token))
-        if not resp.ok:
-            raise RuntimeError(f"Invoices failed with status {resp.status_code}: {resp.text[:200]}")
+        resp = self._get_authenticated(invoices_url, "Invoices")
         return invoices_from_dict(resp.json())
 
     def login(self) -> str:
-        _LOGGER.debug("PgnigApi.login() delegating to %s", type(self._auth).__name__)
-        return self._auth.login()
+        with self._login_lock:
+            _LOGGER.debug("PgnigApi.login() delegating to %s", type(self._auth).__name__)
+            return self._auth.login()

--- a/custom_components/pgnig_gas_sensor/__init__.py
+++ b/custom_components/pgnig_gas_sensor/__init__.py
@@ -2,15 +2,26 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry
+from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DOMAIN, CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD, CONF_ORLEN_SESSION
+from .auth.exceptions import InvalidAuthError, MfaRequired, SessionExpiredError
+from .const import (
+    AUTH_METHOD_ORLEN_ID,
+    CONF_AUTH_METHOD,
+    CONF_ORLEN_SESSION,
+    DEFAULT_AUTH_METHOD,
+    DOMAIN,
+    ORLEN_SESSION_REFRESH_MINUTES,
+)
 from .PgnigApi import PgnigApi
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,7 +78,55 @@ async def async_setup_entry(hass, config_entry):
     )
     _LOGGER.debug("Registered service %s.refresh", DOMAIN)
 
+    if auth_method == AUTH_METHOD_ORLEN_ID:
+
+        @callback
+        def _schedule_orlen_session_refresh(_now) -> None:
+            hass.async_create_task(
+                _async_refresh_orlen_session(hass, config_entry)
+            )
+
+        config_entry.async_on_unload(
+            async_track_time_interval(
+                hass,
+                _schedule_orlen_session_refresh,
+                timedelta(minutes=ORLEN_SESSION_REFRESH_MINUTES),
+            )
+        )
+
     return True
+
+
+async def _async_refresh_orlen_session(hass: HomeAssistant, config_entry) -> None:
+    """Refresh OrlenID cookies/token in the background without MFA."""
+    api = hass.data[DOMAIN].get(config_entry.entry_id)
+    if api is None:
+        return
+
+    def _refresh() -> tuple[str, dict | None]:
+        token = api.refresh_auth_token()
+        return token, api.export_orlen_session()
+
+    try:
+        token, session = await hass.async_add_executor_job(_refresh)
+    except (MfaRequired, InvalidAuthError, SessionExpiredError) as err:
+        _LOGGER.warning(
+            "OrlenID session expired and requires re-authentication: %s", err
+        )
+        hass.async_create_task(hass.config_entries.async_start_reauth(config_entry))
+        return
+    except Exception as err:
+        _LOGGER.warning("Background OrlenID session refresh failed: %s", err)
+        return
+
+    if not token or not session:
+        return
+
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={**config_entry.data, CONF_ORLEN_SESSION: session},
+    )
+    _LOGGER.debug("OrlenID session refreshed in background")
 
 
 async def async_unload_entry(hass, config_entry):

--- a/custom_components/pgnig_gas_sensor/auth/__init__.py
+++ b/custom_components/pgnig_gas_sensor/auth/__init__.py
@@ -63,5 +63,11 @@ def device_id(username: str) -> str:
 
 
 from .api_login import ApiLoginAuth  # noqa: E402
-from .exceptions import AuthError, InvalidAuthError, MfaFailedError, MfaRequired  # noqa: E402
+from .exceptions import (  # noqa: E402
+    AuthError,
+    InvalidAuthError,
+    MfaFailedError,
+    MfaRequired,
+    SessionExpiredError,
+)
 from .orlen_id import OrlenIDAuth  # noqa: E402

--- a/custom_components/pgnig_gas_sensor/auth/__init__.py
+++ b/custom_components/pgnig_gas_sensor/auth/__init__.py
@@ -31,6 +31,10 @@ class AuthMethod(ABC):
     def login(self) -> str:
         pass
 
+    @abstractmethod
+    def invalidate_token(self) -> None:
+        pass
+
 
 class AuthRegistry:
     _methods: dict[str, type[AuthMethod]] = {}

--- a/custom_components/pgnig_gas_sensor/auth/api_login.py
+++ b/custom_components/pgnig_gas_sensor/auth/api_login.py
@@ -57,6 +57,7 @@ class ApiLoginAuth(AuthMethod):
         _LOGGER.debug("Session init status: %s, cookies: %s", resp.status_code, dict(self._session.cookies))
 
     def invalidate_token(self) -> None:
+        """Drop in-memory API token so the next login() fetches a fresh one."""
         _LOGGER.debug("Invalidating cached auth token")
         self._cached_token = ""
 
@@ -97,7 +98,3 @@ class ApiLoginAuth(AuthMethod):
         self._cached_token = token
         _LOGGER.debug("Token obtained: %s...", token[:20])
         return token
-
-    def invalidate_token(self) -> None:
-        """Drop in-memory API token so the next login() fetches a fresh one."""
-        self._cached_token = ""

--- a/custom_components/pgnig_gas_sensor/auth/api_login.py
+++ b/custom_components/pgnig_gas_sensor/auth/api_login.py
@@ -56,6 +56,10 @@ class ApiLoginAuth(AuthMethod):
         resp = self._session.get(BASE_URL, timeout=30)
         _LOGGER.debug("Session init status: %s, cookies: %s", resp.status_code, dict(self._session.cookies))
 
+    def invalidate_token(self) -> None:
+        _LOGGER.debug("Invalidating cached auth token")
+        self._cached_token = ""
+
     def login(self) -> str:
         if self._cached_token:
             _LOGGER.debug("Using cached auth token")

--- a/custom_components/pgnig_gas_sensor/auth/api_login.py
+++ b/custom_components/pgnig_gas_sensor/auth/api_login.py
@@ -97,3 +97,7 @@ class ApiLoginAuth(AuthMethod):
         self._cached_token = token
         _LOGGER.debug("Token obtained: %s...", token[:20])
         return token
+
+    def invalidate_token(self) -> None:
+        """Drop in-memory API token so the next login() fetches a fresh one."""
+        self._cached_token = ""

--- a/custom_components/pgnig_gas_sensor/auth/exceptions.py
+++ b/custom_components/pgnig_gas_sensor/auth/exceptions.py
@@ -23,3 +23,7 @@ class MfaFailedError(AuthError):
 
 class MfaSessionExpiredError(MfaFailedError):
     """MFA session expired; user must log in again with password."""
+
+
+class SessionExpiredError(AuthError):
+    """OIDC session cookies expired; user must re-authenticate in config flow."""

--- a/custom_components/pgnig_gas_sensor/auth/orlen_id.py
+++ b/custom_components/pgnig_gas_sensor/auth/orlen_id.py
@@ -55,6 +55,10 @@ class OrlenIDAuth(AuthMethod):
         resp = self._session.get(BASE_URL, timeout=30)
         _LOGGER.debug("Session init status: %s, cookies: %s", resp.status_code, dict(self._session.cookies))
 
+    def invalidate_token(self) -> None:
+        _LOGGER.debug("Invalidating cached auth token")
+        self._cached_token = ""
+
     def login(self) -> str:
         if self._cached_token:
             _LOGGER.debug("Using cached auth token")

--- a/custom_components/pgnig_gas_sensor/auth/orlen_id.py
+++ b/custom_components/pgnig_gas_sensor/auth/orlen_id.py
@@ -16,6 +16,7 @@ from .exceptions import (
     MfaFailedError,
     MfaRequired,
     MfaSessionExpiredError,
+    SessionExpiredError,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -217,7 +218,7 @@ class OrlenIDAuth(AuthMethod):
                 cookiejar_from_dict(cookies, self._session.cookies)
             elif cookies:
                 _restore_cookies(self._session, cookies)
-            self._cached_token = session_data.get("token", "")
+            # Persisted token is not restored — it expires independently of OIDC cookies.
         self._session.cookies.set("pgnig-ebok-device-token", self._device_id)
 
     @property
@@ -414,7 +415,7 @@ class OrlenIDAuth(AuthMethod):
         }
 
     def _try_restore_session_token(self) -> str | None:
-        if not self._cached_token and not list(self._session.cookies.keys()):
+        if not list(self._session.cookies.keys()):
             return None
         try:
             return self._fetch_auth_token()
@@ -424,10 +425,11 @@ class OrlenIDAuth(AuthMethod):
             return None
 
     def invalidate_token(self) -> None:
+        """Drop in-memory API token so the next login() fetches a fresh one."""
         _LOGGER.debug("Invalidating cached auth token")
         self._cached_token = ""
 
-    def login(self) -> str:
+    def login(self, *, allow_interactive: bool = False) -> str:
         if self._cached_token:
             _LOGGER.debug("Using cached auth token")
             return self._cached_token
@@ -435,6 +437,11 @@ class OrlenIDAuth(AuthMethod):
         restored = self._try_restore_session_token()
         if restored:
             return restored
+
+        if not allow_interactive:
+            raise SessionExpiredError(
+                "OrlenID session expired; re-authenticate in Home Assistant"
+            )
 
         _LOGGER.debug("Starting OrlenID login flow for user %s", self.username)
         self._init_session()

--- a/custom_components/pgnig_gas_sensor/config_flow.py
+++ b/custom_components/pgnig_gas_sensor/config_flow.py
@@ -76,7 +76,9 @@ class PGNIGGasConfigFlow(ConfigFlow, domain=DOMAIN):
         auth_method: str,
     ) -> None:
         api = PgnigApi(username, password, auth_method)
-        await self.hass.async_add_executor_job(api.login)
+        await self.hass.async_add_executor_job(
+            lambda: api.login(allow_interactive=True)
+        )
         self._authenticated_api = api
 
     async def _perform_mfa(self, code: str) -> None:

--- a/custom_components/pgnig_gas_sensor/const.py
+++ b/custom_components/pgnig_gas_sensor/const.py
@@ -6,3 +6,4 @@ CONF_MFA_CODE = "mfa_code"
 CONF_ORLEN_SESSION = "orlen_session"
 DEFAULT_AUTH_METHOD = "api_login"
 AUTH_METHOD_ORLEN_ID = "orlen_id"
+ORLEN_SESSION_REFRESH_MINUTES = 30

--- a/custom_components/pgnig_gas_sensor/sensor.py
+++ b/custom_components/pgnig_gas_sensor/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from .Invoices import InvoicesList
 from .PgnigApi import PgnigApi
 from .PpgReadingForMeter import MeterReading
-from .const import CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD
+from .const import CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -33,10 +33,7 @@ async def async_setup_entry(
         config_entry: ConfigEntry,
         async_add_entities,
 ):
-    user = config_entry.data[CONF_USERNAME]
-    password = config_entry.data[CONF_PASSWORD]
-    auth_method = config_entry.data.get(CONF_AUTH_METHOD, DEFAULT_AUTH_METHOD)
-    api = PgnigApi(user, password, auth_method)
+    api = hass.data[DOMAIN][config_entry.entry_id]
     try:
         pgps = await hass.async_add_executor_job(api.meterList)
     except Exception as err:

--- a/tests/test_api_login.py
+++ b/tests/test_api_login.py
@@ -49,6 +49,12 @@ def test_login_returns_cached_token(auth):
         mock_init.assert_not_called()
 
 
+def test_invalidate_token_clears_cache(auth):
+    auth._cached_token = "cached-token-123"
+    auth.invalidate_token()
+    assert auth._cached_token == ""
+
+
 def test_login_success(auth):
     with patch.object(auth, "_session") as mock_session:
         mock_session.get.return_value = _make_mock_response(status_code=200)

--- a/tests/test_orlen_id.py
+++ b/tests/test_orlen_id.py
@@ -50,6 +50,12 @@ def test_login_returns_cached_token(auth):
         mock_init.assert_not_called()
 
 
+def test_invalidate_token_clears_cache(auth):
+    auth._cached_token = "cached-oid-token"
+    auth.invalidate_token()
+    assert auth._cached_token == ""
+
+
 def test_login_full_flow_success(auth):
     with patch.object(auth, "_session") as mock_session:
         mock_session.get.return_value = _mock_resp(

--- a/tests/test_orlen_id.py
+++ b/tests/test_orlen_id.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 
 from custom_components.pgnig_gas_sensor.auth import AuthRegistry
-from custom_components.pgnig_gas_sensor.auth.exceptions import InvalidAuthError
+from custom_components.pgnig_gas_sensor.auth.exceptions import InvalidAuthError, SessionExpiredError
 
 
 def _mock_resp(json_data=None, status_code=200, text=""):
@@ -46,7 +46,7 @@ def test_info(auth):
 def test_login_returns_cached_token(auth):
     auth._cached_token = "cached-oid-token"
     with patch.object(auth, "_init_session") as mock_init:
-        token = auth.login()
+        token = auth.login(allow_interactive=True)
         assert token == "cached-oid-token"
         mock_init.assert_not_called()
 
@@ -68,7 +68,7 @@ def test_login_full_flow_success(auth):
             _mock_resp(text='<form action="https://oid.example.com/auth">'),
             mock_token_resp,
         ]
-        token = auth.login()
+        token = auth.login(allow_interactive=True)
         assert token == "oid-token-xyz"
         assert auth._cached_token == "oid-token-xyz"
 
@@ -85,7 +85,7 @@ def test_login_raises_when_login_form_missing(auth):
             _mock_resp(text="<html>No form here</html>"),
         ]
         with pytest.raises(RuntimeError, match="login form not found"):
-            auth.login()
+            auth.login(allow_interactive=True)
 
 
 def test_login_raises_invalid_auth_when_not_redirected_to_home(auth):
@@ -103,7 +103,7 @@ def test_login_raises_invalid_auth_when_not_redirected_to_home(auth):
             _mock_resp(text='<form action="https://oid.example.com/auth">'),
         ]
         with pytest.raises(InvalidAuthError):
-            auth.login()
+            auth.login(allow_interactive=True)
 
 
 def test_login_raises_when_auth_token_request_fails(auth):
@@ -122,4 +122,42 @@ def test_login_raises_when_auth_token_request_fails(auth):
             _mock_resp(status_code=401, text="unauthorized"),
         ]
         with pytest.raises(RuntimeError, match="Auth token"):
+            auth.login(allow_interactive=True)
+
+
+def test_session_data_restores_cookies_not_token():
+    cls = AuthRegistry.get("orlen_id")
+    auth = cls(
+        "oid_user@test.pl",
+        "oid_pass",
+        session_data={
+            "device_id": "stored-device",
+            "cookies": [
+                {
+                    "name": "session",
+                    "value": "abc",
+                    "domain": "ebok.myorlen.pl",
+                    "path": "/",
+                }
+            ],
+            "token": "expired-stale-token",
+        },
+    )
+    assert auth._cached_token == ""
+    assert auth._device_id == "stored-device"
+    with patch.object(auth, "_fetch_auth_token", return_value="fresh-token") as mock_fetch:
+        token = auth.login(allow_interactive=True)
+        assert token == "fresh-token"
+        mock_fetch.assert_called_once()
+
+
+def test_login_without_interactive_raises_when_session_expired(auth):
+    with patch.object(auth, "_try_restore_session_token", return_value=None):
+        with pytest.raises(SessionExpiredError):
             auth.login()
+
+
+def test_invalidate_token_clears_cache(auth):
+    auth._cached_token = "cached"
+    auth.invalidate_token()
+    assert auth._cached_token == ""

--- a/tests/test_pgnig_api.py
+++ b/tests/test_pgnig_api.py
@@ -159,3 +159,40 @@ def test_api_uses_auth_session(api, mock_auth):
     call_args = mock_auth.session.get.call_args
     headers = call_args[1]["headers"]
     assert headers["AuthToken"] == "test-token"
+
+
+def test_meter_list_retries_on_401(api, mock_auth):
+    unauthorized = MagicMock()
+    unauthorized.status_code = 401
+    unauthorized.ok = False
+    unauthorized.text = '{"Message": "Authorization has been denied for this request."}'
+
+    authorized = MagicMock()
+    authorized.status_code = 200
+    authorized.ok = True
+    authorized.json.return_value = mock_auth.session.get.return_value.json.return_value
+
+    mock_auth.session.get.side_effect = [unauthorized, authorized]
+    mock_auth.login.side_effect = ["stale-token", "fresh-token"]
+
+    ppg = api.meterList()
+    assert ppg is not None
+    assert mock_auth.login.call_count == 2
+    mock_auth.invalidate_token.assert_called_once()
+    assert mock_auth.session.get.call_count == 2
+    assert mock_auth.session.get.call_args_list[1][1]["headers"]["AuthToken"] == "fresh-token"
+
+
+def test_reading_for_meter_raises_after_repeated_401(api, mock_auth):
+    unauthorized = MagicMock()
+    unauthorized.status_code = 401
+    unauthorized.ok = False
+    unauthorized.text = '{"Message": "Authorization has been denied for this request."}'
+    mock_auth.session.get.side_effect = [unauthorized, unauthorized]
+    mock_auth.login.side_effect = ["stale-token", "fresh-token"]
+
+    with pytest.raises(RuntimeError, match="Reading failed with status 401"):
+        api.readingForMeter("123")
+
+    assert mock_auth.login.call_count == 2
+    mock_auth.invalidate_token.assert_called_once()


### PR DESCRIPTION
Fixes #99

PL
Naprawia problem z brakiem odświeżania danych po wygaśnięciu tokenu EBOK.

Retry przy 401

Przy 401 integracja czyści cache tokenu i ponawia żądanie (raz)
Dotyczy API Login i OrlenID
Sensory używają wspólnej instancji PgnigApi z hass.data
login() jest chroniony lockiem (threading.Lock)
OrlenID - utrzymanie sesji

Token EBOK nie jest przywracany z config entry (wygasa niezależnie od cookies OIDC)
Przy starcie / braku cache: odświeżenie tokenu z zapisanych cookies (_try_restore_session_token)
Co 30 min: tło odświeża token i zapisuje orlen_session w config entry
OrlenID - brak spamu SMS (MFA)

Polling, refresh i timer nie odpalają pełnego logowania z hasłem
Pełny flow z MFA tylko w config flow / reauth (allow_interactive=True)
Przy wygasłej sesji OIDC: SessionExpiredError → powiadomienie o reauth w HA, bez wysyłki SMS
Test plan

 tests/test_pgnig_api.py - retry on 401, lock, invalidate_token()

 tests/test_api_login.py - invalidate_token()

 tests/test_orlen_id.py - cookie restore, allow_interactive, SessionExpiredError

 tests/test_orlen_id_mfa.py - MFA flow w config flow bez regresji
EN
Fixes data refresh after the EBOK auth token expires.

401 retry

On 401, the integration clears the token cache and retries the request (once)
Applies to API Login and OrlenID
Sensors use the shared PgnigApi instance from hass.data
login() is protected by a lock (threading.Lock)
OrlenID session keep-alive

EBOK token is not restored from the config entry (it expires independently of OIDC cookies)
On startup / cache miss: refresh token from stored cookies (_try_restore_session_token)
Every 30 min: background job refreshes the token and persists orlen_session in the config entry
OrlenID - no MFA SMS spam

Polling, manual refresh, and the background timer never start a full password login
Full MFA flow only in config flow / reauth (allow_interactive=True)
When OIDC session expires: SessionExpiredError → reauth notification in HA, no SMS sent
Test plan

 tests/test_pgnig_api.py - retry on 401, lock, invalidate_token()

 tests/test_api_login.py - invalidate_token()

 tests/test_orlen_id.py - cookie restore, allow_interactive, SessionExpiredError

 tests/test_orlen_id_mfa.py - MFA config flow without regressions